### PR TITLE
Manual bitshifting for version class

### DIFF
--- a/include/xmipp4/version.hpp
+++ b/include/xmipp4/version.hpp
@@ -29,14 +29,10 @@
  */
 
 #include "platform/constexpr.hpp"
+#include "utils/bit.hpp"
 
-#include <tuple>
 #include <ostream>
 #include <cstdint>
-
-#define XMIPP4_VERSION_MAJOR_BITS 4
-#define XMIPP4_VERSION_MINOR_BITS 14
-#define XMIPP4_VERSION_PATCH_BITS 14
 
 namespace xmipp4 
 {
@@ -45,36 +41,50 @@ class version
 {
 public:
     version() = default;
-    XMIPP4_CONSTEXPR version(   unsigned major, 
-                                unsigned minor, 
-                                unsigned patch ) noexcept;
+    XMIPP4_CONSTEXPR version(std::uint32_t major, 
+                             std::uint32_t minor, 
+                             std::uint32_t patch ) noexcept;
     version(const version& other) = default;
     ~version() = default;
 
     version& operator=(const version& other) = default;
+
+    XMIPP4_CONSTEXPR bool operator==(const version& rhs) noexcept;
+    XMIPP4_CONSTEXPR bool operator!=(const version& rhs) noexcept;
+    XMIPP4_CONSTEXPR bool operator<(const version& rhs) noexcept;
+    XMIPP4_CONSTEXPR bool operator<=(const version& rhs) noexcept;
+    XMIPP4_CONSTEXPR bool operator>(const version& rhs) noexcept;
+    XMIPP4_CONSTEXPR bool operator>=(const version& rhs) noexcept;
     
-    XMIPP4_CONSTEXPR void set_major(unsigned major) noexcept;
-    XMIPP4_CONSTEXPR unsigned get_major() const noexcept;
+    XMIPP4_CONSTEXPR void set_major(std::uint32_t major) noexcept;
+    XMIPP4_CONSTEXPR std::uint32_t get_major() const noexcept;
 
-    XMIPP4_CONSTEXPR void set_minor(unsigned minor) noexcept;
-    XMIPP4_CONSTEXPR unsigned get_minor() const noexcept;
+    XMIPP4_CONSTEXPR void set_minor(std::uint32_t minor) noexcept;
+    XMIPP4_CONSTEXPR std::uint32_t get_minor() const noexcept;
 
-    XMIPP4_CONSTEXPR void set_patch(unsigned patch) noexcept;
-    XMIPP4_CONSTEXPR unsigned get_patch() const noexcept;
+    XMIPP4_CONSTEXPR void set_patch(std::uint32_t patch) noexcept;
+    XMIPP4_CONSTEXPR std::uint32_t get_patch() const noexcept;
 
 private:
-    uint32_t m_major : XMIPP4_VERSION_MAJOR_BITS;
-    uint32_t m_minor : XMIPP4_VERSION_MINOR_BITS;
-    uint32_t m_patch : XMIPP4_VERSION_PATCH_BITS;
+    static XMIPP4_INLINE_CONST_CONSTEXPR std::size_t patch_bits = 10;
+    static XMIPP4_INLINE_CONST_CONSTEXPR std::size_t minor_bits = 10;
+    static XMIPP4_INLINE_CONST_CONSTEXPR std::size_t major_bits = 12;
+
+    static XMIPP4_INLINE_CONST_CONSTEXPR std::size_t patch_offset = 0;
+    static XMIPP4_INLINE_CONST_CONSTEXPR std::size_t minor_offset = patch_offset + patch_bits;
+    static XMIPP4_INLINE_CONST_CONSTEXPR std::size_t major_offset = minor_offset + minor_bits;
+
+    static XMIPP4_INLINE_CONST_CONSTEXPR std::uint32_t patch_mask = 
+        utils::bit_range_mask<std::uint32_t>(patch_offset, patch_offset+patch_bits);
+    static XMIPP4_INLINE_CONST_CONSTEXPR std::uint32_t minor_mask = 
+        utils::bit_range_mask<std::uint32_t>(minor_offset, minor_offset+minor_bits);
+    static XMIPP4_INLINE_CONST_CONSTEXPR std::uint32_t major_mask = 
+        utils::bit_range_mask<std::uint32_t>(major_offset, major_offset+major_bits);
+
+    std::uint32_t m_data;
 
 };
 
-XMIPP4_CONSTEXPR bool operator==(const version& lhs, const version& rhs) noexcept;
-XMIPP4_CONSTEXPR bool operator!=(const version& lhs, const version& rhs) noexcept;
-XMIPP4_CONSTEXPR bool operator<(const version& lhs, const version& rhs) noexcept;
-XMIPP4_CONSTEXPR bool operator<=(const version& lhs, const version& rhs) noexcept;
-XMIPP4_CONSTEXPR bool operator>(const version& lhs, const version& rhs) noexcept;
-XMIPP4_CONSTEXPR bool operator>=(const version& lhs, const version& rhs) noexcept;
 
 template<typename T>
 std::basic_ostream<T>& operator<<(std::basic_ostream<T>& os, const version& ver);

--- a/include/xmipp4/version.inl
+++ b/include/xmipp4/version.inl
@@ -31,103 +31,102 @@
 namespace xmipp4 
 {
 
-XMIPP4_INLINE_CONSTEXPR version::version( unsigned major, 
-                            unsigned minor, 
-                            unsigned patch ) noexcept
-    : m_major(major)
-    , m_minor(minor)
-    , m_patch(patch)
+XMIPP4_INLINE_CONSTEXPR 
+version::version(std::uint32_t major, 
+                 std::uint32_t minor, 
+                 std::uint32_t patch ) noexcept
+    : m_data(major) // No need to mask, as it will be shifted
 {
+    // Shift and write fields
+    XMIPP4_CONST_CONSTEXPR std::uint32_t minor_mask = (1 << minor_bits) - 1;
+    m_data <<= minor_bits;
+    m_data |= minor & minor_mask;
+
+    XMIPP4_CONST_CONSTEXPR std::uint32_t patch_mask = (1 << patch_bits) - 1;
+    m_data <<= patch_bits;
+    m_data |= patch & patch_mask;
 }
 
-XMIPP4_INLINE_CONSTEXPR void 
-version::set_major(unsigned major) noexcept
+XMIPP4_INLINE_CONSTEXPR 
+bool version::operator==(const version& other) noexcept
 {
-    m_major = major;
+    return m_data == other.m_data;
 }
 
-XMIPP4_INLINE_CONSTEXPR unsigned 
-version::get_major() const noexcept
+XMIPP4_INLINE_CONSTEXPR 
+bool version::operator!=(const version& other) noexcept
 {
-    return m_major;
+    return m_data != other.m_data;
 }
 
-XMIPP4_INLINE_CONSTEXPR void 
-version::set_minor(unsigned minor) noexcept
+XMIPP4_INLINE_CONSTEXPR 
+bool version::operator<(const version& other) noexcept
 {
-    m_minor = minor;
+    return m_data < other.m_data;
 }
 
-XMIPP4_INLINE_CONSTEXPR unsigned 
-version::get_minor() const noexcept
+XMIPP4_INLINE_CONSTEXPR 
+bool version::operator<=(const version& other) noexcept
 {
-    return m_minor;
+    return m_data <= other.m_data;
 }
 
-XMIPP4_INLINE_CONSTEXPR void 
-version::set_patch(unsigned patch) noexcept
+XMIPP4_INLINE_CONSTEXPR 
+bool version::operator>(const version& other) noexcept
 {
-    m_patch = patch;
+    return m_data > other.m_data;
 }
 
-XMIPP4_INLINE_CONSTEXPR unsigned 
-version::get_patch() const noexcept
+XMIPP4_INLINE_CONSTEXPR 
+bool version::operator>=(const version& other) noexcept
 {
-    return m_patch;
+    return m_data >= other.m_data;
+}
+
+XMIPP4_INLINE_CONSTEXPR 
+void version::set_major(std::uint32_t major) noexcept
+{
+    major <<= major_offset;
+    m_data &= ~major_mask;
+    m_data |= major;
+}
+
+XMIPP4_INLINE_CONSTEXPR 
+std::uint32_t version::get_major() const noexcept
+{
+    return m_data >> major_offset;
+}
+
+XMIPP4_INLINE_CONSTEXPR 
+void version::set_minor(std::uint32_t minor) noexcept
+{
+    minor <<= minor_offset;
+    minor &= minor_mask;
+    m_data &= ~minor_mask;
+    m_data |= minor;
+}
+
+XMIPP4_INLINE_CONSTEXPR 
+std::uint32_t version::get_minor() const noexcept
+{
+    return (m_data & minor_mask) >> minor_bits;
+}
+
+XMIPP4_INLINE_CONSTEXPR 
+void version::set_patch(std::uint32_t patch) noexcept
+{
+    patch &= patch_mask;
+    m_data &= ~patch_mask;
+    m_data |= patch;
+}
+
+XMIPP4_INLINE_CONSTEXPR 
+std::uint32_t version::get_patch() const noexcept
+{
+    return m_data & patch_mask;
 }
 
 
-
-namespace detail
-{
-
-XMIPP4_INLINE_CONSTEXPR std::tuple<unsigned, unsigned, unsigned>
-as_tuple(const version& version) noexcept
-{
-    return std::make_tuple(
-        version.get_major(),
-        version.get_minor(),
-        version.get_patch()
-    );
-}
-
-}
-
-XMIPP4_INLINE_CONSTEXPR bool 
-operator==(const version& lhs, const version& rhs) noexcept
-{
-    return detail::as_tuple(lhs) == detail::as_tuple(rhs);
-}
-
-XMIPP4_INLINE_CONSTEXPR bool 
-operator!=(const version& lhs, const version& rhs) noexcept
-{
-    return detail::as_tuple(lhs) != detail::as_tuple(rhs);
-}
-
-XMIPP4_INLINE_CONSTEXPR bool 
-operator<(const version& lhs, const version& rhs) noexcept
-{
-    return detail::as_tuple(lhs) < detail::as_tuple(rhs);
-}
-
-XMIPP4_INLINE_CONSTEXPR bool 
-operator<=(const version& lhs, const version& rhs) noexcept
-{
-    return detail::as_tuple(lhs) <= detail::as_tuple(rhs);
-}
-
-XMIPP4_INLINE_CONSTEXPR bool 
-operator>(const version& lhs, const version& rhs) noexcept
-{
-    return detail::as_tuple(lhs) > detail::as_tuple(rhs);
-}
-
-XMIPP4_INLINE_CONSTEXPR bool 
-operator>=(const version& lhs, const version& rhs) noexcept
-{
-    return detail::as_tuple(lhs) >= detail::as_tuple(rhs);
-}
 
 template<typename T>
 inline std::basic_ostream<T>& 

--- a/tests/test_version.cpp
+++ b/tests/test_version.cpp
@@ -37,29 +37,44 @@ TEST_CASE( "version constructor and getters", "[version]" )
 {
     SECTION( "piecewise constructor" )
     {
-        version v(1, 2, 3);
-        REQUIRE( v.get_major() == 1 );
-        REQUIRE( v.get_minor() == 2 );
-        REQUIRE( v.get_patch() == 3 );
+        version v(1234, 567, 890);
+        REQUIRE( v.get_major() == 1234 );
+        REQUIRE( v.get_minor() == 567 );
+        REQUIRE( v.get_patch() == 890 );
     }
 
     SECTION( "copy constructor" )
     {
-        version v(1, 2, 3);
+        version v(2345, 678, 901);
         version v2(v);
-        REQUIRE( v2.get_major() == 1 );
-        REQUIRE( v2.get_minor() == 2 );
-        REQUIRE( v2.get_patch() == 3 );
+        REQUIRE( v2.get_major() == 2345 );
+        REQUIRE( v2.get_minor() == 678 );
+        REQUIRE( v2.get_patch() == 901 );
     }
 }
 
 TEST_CASE( "version setters and getters", "[version]" ) 
 {
     version v(1, 2, 3);
-    v.set_major(4);
-    v.set_minor(5);
-    v.set_patch(6);
-    REQUIRE( v.get_major() == 4 );
-    REQUIRE( v.get_minor() == 5 );
-    REQUIRE( v.get_patch() == 6 );
+    v.set_major(3971);
+    v.set_minor(999);
+    v.set_patch(997);
+    REQUIRE( v.get_major() == 3971 );
+    REQUIRE( v.get_minor() == 999 );
+    REQUIRE( v.get_patch() == 997 );
+}
+
+TEST_CASE( "version overflow", "[version]" ) 
+{
+    version v(4096, 1024, 1024);
+    REQUIRE( v.get_major() == 0 );
+    REQUIRE( v.get_minor() == 0 );
+    REQUIRE( v.get_patch() == 0 );
+
+    v.set_major(8193);
+    v.set_minor(2049);
+    v.set_patch(2049);
+    REQUIRE( v.get_major() == 1 );
+    REQUIRE( v.get_minor() == 1 );
+    REQUIRE( v.get_patch() == 1 );
 }


### PR DESCRIPTION
Although code becomes more low-level, the ABI compatibility is improved. In any case, these changes are scoped to the class itself and do not modify the API of the class.