### PR TITLE
Added image::location class

### DIFF
--- a/include/xmipp4/core/image/location.hpp
+++ b/include/xmipp4/core/image/location.hpp
@@ -31,6 +31,7 @@
 #include "../platform/constexpr.hpp"
 
 #include <string>
+#include <ostream>
 
 namespace xmipp4 
 {
@@ -129,6 +130,9 @@ private:
  * @return false On failure.
  */
 bool parse_location(const std::string &path, location &result);
+
+template <typename T>
+std::basic_ostream<T>& operator<<(std::basic_ostream<T> &os, const location &loc);
 
 } // namespace image
 } // namespace xmipp4

--- a/include/xmipp4/core/image/location.inl
+++ b/include/xmipp4/core/image/location.inl
@@ -133,5 +133,19 @@ bool parse_location(const std::string &path, location &result)
     return success;
 }
 
+template <typename T>
+inline
+std::basic_ostream<T>& operator<<(std::basic_ostream<T> &os, const location &loc)
+{
+    if(loc.get_position() != location::no_position)
+    {
+        XMIPP4_CONST_CONSTEXPR T separator = '@';
+        os << loc.get_position() << separator;
+
+    }
+
+    return os << loc.get_filename();
+}
+
 } // namespace image
 } // namespace xmipp4

--- a/tests/image/test_location.cpp
+++ b/tests/image/test_location.cpp
@@ -31,10 +31,11 @@
 #include <xmipp4/core/image/location.hpp>
 
 #include <string>
+#include <sstream>
 
 using namespace xmipp4::image;
 
-TEST_CASE("parse image location", "[memory_layout]")
+TEST_CASE("parse image location", "[image location]")
 {
     SECTION("without position")
     {
@@ -64,5 +65,22 @@ TEST_CASE("parse image location", "[memory_layout]")
         REQUIRE( !parse_location(path, loc) );
         REQUIRE( loc.get_filename() == "previous/filename" );
         REQUIRE( loc.get_position() == 987 );
+    }
+}
+
+TEST_CASE("image location to ostream", "[image location]")
+{
+    std::ostringstream oss;
+
+    SECTION("without position")
+    {
+        oss << location("example/location", location::no_position);
+        REQUIRE( oss.str() == "example/location" );
+    }
+
+    SECTION("with position")
+    {
+        oss << location("example/location", 1234);
+        REQUIRE( oss.str() == "1234@example/location" );
     }
 }


### PR DESCRIPTION
The image::location class references an image on the filesystem, considering that a image file may contain multiple images (stack). No behavioral change from Xmipp3/Scipion.