### PR TITLE
Fixed warning

### DIFF
--- a/include/xmipp4/core/platform/cpp_features.hpp
+++ b/include/xmipp4/core/platform/cpp_features.hpp
@@ -49,7 +49,7 @@
  * 
  */
 #define XMIPP4_HAS_CPP_FEATURE(feature, version) \
-    ((defined(__cpp_##feature) && (__cpp_##feature >= version)) || \
+    ((__cpp_##feature >= version) || \
     (XMIPP4_HAS_C_FEATURE(cxx_##feature) && XMIPP4_CPLUSPLUS >= version))
 
 /**


### PR DESCRIPTION
Getting compiler warning about using macro expansion inside `defined` macro function. Removed redundant code to fix the warning.