### PR TITLE
Using trompeloeil for mocking

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -32,6 +32,15 @@ FetchContent_Declare(
   GIT_TAG        v3.5.4
 )
 FetchContent_MakeAvailable(Catch2)
+
+# Fetch Trompeloeil
+FetchContent_Declare(
+  Trompeloeil
+  GIT_REPOSITORY https://github.com/rollbear/trompeloeil.git
+  GIT_TAG        v49
+)
+FetchContent_MakeAvailable(Trompeloeil)
+
 include(Catch)
 
 add_subdirectory(unitary)

--- a/tests/unitary/CMakeLists.txt
+++ b/tests/unitary/CMakeLists.txt
@@ -47,6 +47,7 @@ target_link_libraries(
 	PRIVATE 
 		${PROJECT_NAME} 
 		Catch2::Catch2WithMain
+		trompeloeil::trompeloeil
 )
 
 # On windows targets, copy the library to the test directory

--- a/tests/unitary/src/communication/test_communicator_manager.cpp
+++ b/tests/unitary/src/communication/test_communicator_manager.cpp
@@ -25,16 +25,15 @@
  * @date 2024-10-29
  */
 
-
-#include <catch2/catch_test_macros.hpp>
-#include <trompeloeil.hpp>
-
 #include <xmipp4/core/communication/communicator_manager.hpp>
 
 #include <xmipp4/core/communication/communicator_backend.hpp>
 #include <xmipp4/core/version.hpp>
 
 #include <algorithm>
+
+#include <catch2/catch_test_macros.hpp>
+#include <trompeloeil.hpp>
 
 using namespace xmipp4;
 using namespace xmipp4::communication;

--- a/tests/unitary/src/communication/test_communicator_manager.cpp
+++ b/tests/unitary/src/communication/test_communicator_manager.cpp
@@ -42,10 +42,10 @@ class mock_communicator_backend final
     : public communicator_backend
 {
 public:
-    MAKE_MOCK(get_name, auto () -> const std::string&, const noexcept override);
-    MAKE_MOCK(get_version, auto () -> version, const noexcept override);
-    MAKE_MOCK(is_available, auto () -> bool, const noexcept override);
-    MAKE_MOCK(get_world_communicator, auto () -> std::shared_ptr<communicator>, const override);
+    MAKE_MOCK0(get_name, const std::string& (), const noexcept override);
+    MAKE_MOCK0(get_version, version (), const noexcept override);
+    MAKE_MOCK0(is_available, bool (), const noexcept override);
+    MAKE_MOCK0(get_world_communicator, std::shared_ptr<communicator> (), const override);
 
 };
 

--- a/tests/unitary/src/communication/test_communicator_manager.cpp
+++ b/tests/unitary/src/communication/test_communicator_manager.cpp
@@ -56,13 +56,13 @@ TEST_CASE( "register communicator backend", "[communicator_manager]" )
     const std::string name1 = "mock1";
     REQUIRE_CALL(*mock1, get_name())
         .RETURN(name1)
-        .TIMES(AT_LEAST(1));
+        .TIMES(1);
 
     auto mock2 = std::make_unique<mock_communicator_backend>();
     const std::string name2 = "mock2";
     REQUIRE_CALL(*mock2, get_name())
         .RETURN(name2)
-        .TIMES(AT_LEAST(1));
+        .TIMES(1);
 
     // Test
     communicator_manager manager;
@@ -85,13 +85,13 @@ TEST_CASE( "query communicator backend", "[communicator_manager]" )
     const std::string name1 = "mock1";
     REQUIRE_CALL(*mock1, get_name())
         .RETURN(name1)
-        .TIMES(AT_LEAST(2));
+        .TIMES(2);
 
     auto mock2 = std::make_unique<mock_communicator_backend>();
     const std::string name2 = "mock2";
     REQUIRE_CALL(*mock2, get_name())
         .RETURN(name2)
-        .TIMES(AT_LEAST(2));
+        .TIMES(2);
 
     // Test
     communicator_manager manager;
@@ -117,12 +117,12 @@ TEST_CASE( "register the same communicator backend twice", "[communicator_manage
     auto mock1 = std::make_unique<mock_communicator_backend>();
     REQUIRE_CALL(*mock1, get_name())
         .RETURN(name)
-        .TIMES(AT_LEAST(1));
+        .TIMES(1);
 
     auto mock2 = std::make_unique<mock_communicator_backend>();
     REQUIRE_CALL(*mock2, get_name())
         .RETURN(name)
-        .TIMES(AT_LEAST(1));
+        .TIMES(1);
 
     // Test
     communicator_manager manager;

--- a/tests/unitary/src/communication/test_communicator_manager.cpp
+++ b/tests/unitary/src/communication/test_communicator_manager.cpp
@@ -27,6 +27,7 @@
 
 
 #include <catch2/catch_test_macros.hpp>
+#include <trompeloeil.hpp>
 
 #include <xmipp4/core/communication/communicator_manager.hpp>
 
@@ -38,84 +39,100 @@
 using namespace xmipp4;
 using namespace xmipp4::communication;
 
-class test_communicator_backend
+class mock_communicator_backend final
     : public communicator_backend
 {
 public:
-    test_communicator_backend(std::string name)
-        : m_name(std::move(name))
-    {
-    }
-
-    const std::string& get_name() const noexcept final
-    {
-        return m_name;
-    }
-
-    version get_version() const noexcept final
-    {
-        return version(2, 4, 5);
-    }
-
-    bool is_available() const noexcept final
-    {
-        return true;
-    }
-
-    std::shared_ptr<communicator> 
-    get_world_communicator() const final
-    {
-        return nullptr;
-    }
-
-private:
-    std::string m_name;
+    MAKE_MOCK(get_name, auto () -> const std::string&, const noexcept override);
+    MAKE_MOCK(get_version, auto () -> version, const noexcept override);
+    MAKE_MOCK(is_available, auto () -> bool, const noexcept override);
+    MAKE_MOCK(get_world_communicator, auto () -> std::shared_ptr<communicator>, const override);
 
 };
 
-
 TEST_CASE( "register communicator backend", "[communicator_manager]" ) 
 {
+    // Setup mocks
+    auto mock1 = std::make_unique<mock_communicator_backend>();
+    const std::string name1 = "mock1";
+    REQUIRE_CALL(*mock1, get_name())
+        .RETURN(name1)
+        .TIMES(AT_LEAST(1));
+
+    auto mock2 = std::make_unique<mock_communicator_backend>();
+    const std::string name2 = "mock2";
+    REQUIRE_CALL(*mock2, get_name())
+        .RETURN(name2)
+        .TIMES(AT_LEAST(1));
+
+    // Test
     communicator_manager manager;
-    manager.register_backend(std::make_unique<test_communicator_backend>("test1"));
-    manager.register_backend(std::make_unique<test_communicator_backend>("test2"));
+    manager.register_backend(std::move(mock1));
+    manager.register_backend(std::move(mock2));
 
     std::vector<std::string> backends;
     manager.enumerate_backends(backends);
 
     REQUIRE( backends.size() == 2 );
     std::sort(backends.begin(), backends.end()); // Ordering not defined
-    REQUIRE( backends[0] == "test1" );
-    REQUIRE( backends[1] == "test2" );
+    REQUIRE( backends[0] == name1 );
+    REQUIRE( backends[1] == name2 );
 }
 
 TEST_CASE( "query communicator backend", "[communicator_manager]" ) 
 {
+    // Setup mocks
+    auto mock1 = std::make_unique<mock_communicator_backend>();
+    const std::string name1 = "mock1";
+    REQUIRE_CALL(*mock1, get_name())
+        .RETURN(name1)
+        .TIMES(AT_LEAST(2));
+
+    auto mock2 = std::make_unique<mock_communicator_backend>();
+    const std::string name2 = "mock2";
+    REQUIRE_CALL(*mock2, get_name())
+        .RETURN(name2)
+        .TIMES(AT_LEAST(2));
+
+    // Test
     communicator_manager manager;
-    manager.register_backend(std::make_unique<test_communicator_backend>("test1"));
-    manager.register_backend(std::make_unique<test_communicator_backend>("test2"));
+    manager.register_backend(std::move(mock1));
+    manager.register_backend(std::move(mock2));
 
     communicator_backend* backend;
-    backend = manager.get_backend("test1");
+    backend = manager.get_backend(name1);
     REQUIRE( backend != nullptr );
-    REQUIRE( backend->get_name() == "test1" );
+    REQUIRE( backend->get_name() == name1 );
 
-    backend = manager.get_backend("test2");
+    backend = manager.get_backend(name2);
     REQUIRE( backend != nullptr );
-    REQUIRE( backend->get_name() == "test2" );
+    REQUIRE( backend->get_name() == name2 );
 
     REQUIRE( manager.get_backend("not-a-backend") == nullptr );
 }
 
 TEST_CASE( "register the same communicator backend twice", "[communicator_manager]" ) 
 {
+    // Setup mocks
+    const std::string name = "mock1";
+    auto mock1 = std::make_unique<mock_communicator_backend>();
+    REQUIRE_CALL(*mock1, get_name())
+        .RETURN(name)
+        .TIMES(AT_LEAST(1));
+
+    auto mock2 = std::make_unique<mock_communicator_backend>();
+    REQUIRE_CALL(*mock2, get_name())
+        .RETURN(name)
+        .TIMES(AT_LEAST(1));
+
+    // Test
     communicator_manager manager;
-    manager.register_backend(std::make_unique<test_communicator_backend>("test"));
-    manager.register_backend(std::make_unique<test_communicator_backend>("test"));
+    manager.register_backend(std::move(mock1));
+    manager.register_backend(std::move(mock2));
 
     std::vector<std::string> backends;
     manager.enumerate_backends(backends);
 
     REQUIRE( backends.size() == 1 );
-    REQUIRE( backends[0] == "test" );
+    REQUIRE( backends[0] == name );
 }

--- a/tests/unitary/src/compute/test_device_manager.cpp
+++ b/tests/unitary/src/compute/test_device_manager.cpp
@@ -31,125 +31,155 @@
 #include <xmipp4/core/compute/device_backend.hpp>
 #include <xmipp4/core/version.hpp>
 
+#include <algorithm>
+
 #include <catch2/catch_test_macros.hpp>
+#include <trompeloeil.hpp>
 
 using namespace xmipp4;
 using namespace xmipp4::compute;
 
-class test_device_backend
+class mock_device_backend final
     : public device_backend
 {
 public:
-    test_device_backend(std::string name)
-        : m_name(std::move(name))
-    {
-    }
-
-    const std::string& get_name() const noexcept final
-    {
-        return m_name;
-    }
-
-    version get_version() const noexcept final
-    {
-        return version(2, 4, 5);
-    }
-
-    bool is_available() const noexcept final
-    {
-        return true;
-    }
-
-    void enumerate_devices(std::vector<std::size_t> &ids) const final
-    {
-        ids = { 1, 2, 3, 4 };
-    }
-
-    bool get_device_properties(std::size_t, device_properties&) const final
-    {
-        return true;
-    }
-
-    std::unique_ptr<device> create_device(std::size_t) final
-    {
-        return nullptr;
-    }
-
-    std::shared_ptr<device> create_device_shared(std::size_t) final
-    {
-        return nullptr;
-    }
-
-private:
-    std::string m_name;
+    MAKE_MOCK(get_name, auto () -> const std::string&, const noexcept override);
+    MAKE_MOCK(get_version, auto () -> version, const noexcept override);
+    MAKE_MOCK(is_available, auto () -> bool, const noexcept override);
+    MAKE_MOCK(enumerate_devices, auto (std::vector<std::size_t>&) -> void, const override);
+    MAKE_MOCK(get_device_properties, auto (std::size_t, device_properties&) -> bool, const override);
+    MAKE_MOCK(create_device, auto (std::size_t) -> std::unique_ptr<device>, override);
+    MAKE_MOCK(create_device_shared, auto (std::size_t) -> std::shared_ptr<device>, override);
 
 };
 
 
 TEST_CASE( "register device backend", "[device_manager]" ) 
 {
+    // Setup mocks
+    auto mock1 = std::make_unique<mock_device_backend>();
+    const std::string name1 = "mock1";
+    REQUIRE_CALL(*mock1, get_name())
+        .RETURN(name1)
+        .TIMES(AT_LEAST(1));
+
+    auto mock2 = std::make_unique<mock_device_backend>();
+    const std::string name2 = "mock2";
+    REQUIRE_CALL(*mock2, get_name())
+        .RETURN(name2)
+        .TIMES(AT_LEAST(1));
+
+    // Test
     device_manager manager;
-    manager.register_backend(std::make_unique<test_device_backend>("test1"));
-    manager.register_backend(std::make_unique<test_device_backend>("test2"));
+    manager.register_backend(std::move(mock1));
+    manager.register_backend(std::move(mock2));
 
     std::vector<std::string> backends;
     manager.enumerate_backends(backends);
 
     REQUIRE( backends.size() == 2 );
     std::sort(backends.begin(), backends.end()); // Ordering not defined
-    REQUIRE( backends[0] == "test1" );
-    REQUIRE( backends[1] == "test2" );
+    REQUIRE( backends[0] == name1 );
+    REQUIRE( backends[1] == name2 );
 }
 
 TEST_CASE( "query device backend", "[device_manager]" ) 
 {
-    device_manager manager;
-    manager.register_backend(std::make_unique<test_device_backend>("test1"));
-    manager.register_backend(std::make_unique<test_device_backend>("test2"));
+    // Setup mocks
+    auto mock1 = std::make_unique<mock_device_backend>();
+    const std::string name1 = "mock1";
+    REQUIRE_CALL(*mock1, get_name())
+        .RETURN(name1)
+        .TIMES(AT_LEAST(2));
 
+    auto mock2 = std::make_unique<mock_device_backend>();
+    const std::string name2 = "mock2";
+    REQUIRE_CALL(*mock2, get_name())
+        .RETURN(name2)
+        .TIMES(AT_LEAST(2));
+
+    // Test
+    device_manager manager;
+    manager.register_backend(std::move(mock1));
+    manager.register_backend(std::move(mock2));
 
     device_backend* backend;
-    backend = manager.get_backend("test1");
+    backend = manager.get_backend(name1);
     REQUIRE( backend != nullptr );
-    REQUIRE( backend->get_name() == "test1" );
+    REQUIRE( backend->get_name() == name1 );
 
-    backend = manager.get_backend("test2");
+    backend = manager.get_backend(name2);
     REQUIRE( backend != nullptr );
-    REQUIRE( backend->get_name() == "test2" );
+    REQUIRE( backend->get_name() == name2 );
 
     REQUIRE( manager.get_backend("not-a-backend") == nullptr );
 }
 
 TEST_CASE( "register the same device backend twice", "[device_manager]" ) 
 {
+    // Setup mocks
+    const std::string name = "mock";
+    auto mock1 = std::make_unique<mock_device_backend>();
+    REQUIRE_CALL(*mock1, get_name())
+        .RETURN(name)
+        .TIMES(AT_LEAST(1));
+
+    auto mock2 = std::make_unique<mock_device_backend>();
+    REQUIRE_CALL(*mock2, get_name())
+        .RETURN(name)
+        .TIMES(AT_LEAST(1));
+
+    // Test
     device_manager manager;
-    manager.register_backend(std::make_unique<test_device_backend>("test"));
-    manager.register_backend(std::make_unique<test_device_backend>("test"));
+    manager.register_backend(std::move(mock1));
+    manager.register_backend(std::move(mock2));
 
     std::vector<std::string> backends;
     manager.enumerate_backends(backends);
 
     REQUIRE( backends.size() == 1 );
-    REQUIRE( backends[0] == "test" );
+    REQUIRE( backends[0] == name );
 }
 
 TEST_CASE( "enumerate devices", "[device_manager]" ) 
 {
+    // Setup mocks
+    auto mock1 = std::make_unique<mock_device_backend>();
+    const std::string name1 = "mock1";
+    REQUIRE_CALL(*mock1, get_name())
+        .RETURN(name1)
+        .TIMES(AT_LEAST(1));
+    REQUIRE_CALL(*mock1, enumerate_devices(ANY(std::vector<std::size_t>&)))
+        .SIDE_EFFECT(_1 = {0, 1, 2, 3, 4})   
+        .TIMES(AT_LEAST(1));
+
+    auto mock2 = std::make_unique<mock_device_backend>();
+    const std::string name2 = "mock2";
+    REQUIRE_CALL(*mock2, get_name())
+        .RETURN(name2)
+        .TIMES(AT_LEAST(1));
+    REQUIRE_CALL(*mock2, enumerate_devices(ANY(std::vector<std::size_t>&)))
+        .SIDE_EFFECT(_1 = {6, 7, 8, 9})
+        .TIMES(AT_LEAST(1));
+
+    // Test
     device_manager manager;
-    manager.register_backend(std::make_unique<test_device_backend>("hip"));
-    manager.register_backend(std::make_unique<test_device_backend>("cuda"));
+    manager.register_backend(std::move(mock1));
+    manager.register_backend(std::move(mock2));
     
     std::vector<device_index> devices;
     manager.enumerate_devices(devices);
     std::sort(devices.begin(), devices.end()); // Ordering not defined. 
 
-    REQUIRE( devices.size() == 8 );
-    REQUIRE( devices[0] == device_index("cuda", 1) );
-    REQUIRE( devices[1] == device_index("cuda", 2) );
-    REQUIRE( devices[2] == device_index("cuda", 3) );
-    REQUIRE( devices[3] == device_index("cuda", 4) );
-    REQUIRE( devices[4] == device_index("hip", 1) );
-    REQUIRE( devices[5] == device_index("hip", 2) );
-    REQUIRE( devices[6] == device_index("hip", 3) );
-    REQUIRE( devices[7] == device_index("hip", 4) );
+    REQUIRE( devices.size() == 9 );
+    REQUIRE( devices[0] == device_index(name1, 0) );
+    REQUIRE( devices[1] == device_index(name1, 1) );
+    REQUIRE( devices[2] == device_index(name1, 2) );
+    REQUIRE( devices[3] == device_index(name1, 3) );
+    REQUIRE( devices[4] == device_index(name1, 4) );
+
+    REQUIRE( devices[5] == device_index(name2, 6) );
+    REQUIRE( devices[6] == device_index(name2, 7) );
+    REQUIRE( devices[7] == device_index(name2, 8) );
+    REQUIRE( devices[8] == device_index(name2, 9) );
 }

--- a/tests/unitary/src/compute/test_device_manager.cpp
+++ b/tests/unitary/src/compute/test_device_manager.cpp
@@ -61,13 +61,13 @@ TEST_CASE( "register device backend", "[device_manager]" )
     const std::string name1 = "mock1";
     REQUIRE_CALL(*mock1, get_name())
         .RETURN(name1)
-        .TIMES(AT_LEAST(1));
+        .TIMES(1);
 
     auto mock2 = std::make_unique<mock_device_backend>();
     const std::string name2 = "mock2";
     REQUIRE_CALL(*mock2, get_name())
         .RETURN(name2)
-        .TIMES(AT_LEAST(1));
+        .TIMES(1);
 
     // Test
     device_manager manager;
@@ -90,13 +90,13 @@ TEST_CASE( "query device backend", "[device_manager]" )
     const std::string name1 = "mock1";
     REQUIRE_CALL(*mock1, get_name())
         .RETURN(name1)
-        .TIMES(AT_LEAST(2));
+        .TIMES(2);
 
     auto mock2 = std::make_unique<mock_device_backend>();
     const std::string name2 = "mock2";
     REQUIRE_CALL(*mock2, get_name())
         .RETURN(name2)
-        .TIMES(AT_LEAST(2));
+        .TIMES(2);
 
     // Test
     device_manager manager;
@@ -122,12 +122,12 @@ TEST_CASE( "register the same device backend twice", "[device_manager]" )
     auto mock1 = std::make_unique<mock_device_backend>();
     REQUIRE_CALL(*mock1, get_name())
         .RETURN(name)
-        .TIMES(AT_LEAST(1));
+        .TIMES(1);
 
     auto mock2 = std::make_unique<mock_device_backend>();
     REQUIRE_CALL(*mock2, get_name())
         .RETURN(name)
-        .TIMES(AT_LEAST(1));
+        .TIMES(1);
 
     // Test
     device_manager manager;
@@ -148,19 +148,19 @@ TEST_CASE( "enumerate devices", "[device_manager]" )
     const std::string name1 = "mock1";
     REQUIRE_CALL(*mock1, get_name())
         .RETURN(name1)
-        .TIMES(AT_LEAST(1));
+        .TIMES(1);
     REQUIRE_CALL(*mock1, enumerate_devices(ANY(std::vector<std::size_t>&)))
         .SIDE_EFFECT(_1 = {0, 1, 2, 3, 4})   
-        .TIMES(AT_LEAST(1));
+        .TIMES(1);
 
     auto mock2 = std::make_unique<mock_device_backend>();
     const std::string name2 = "mock2";
     REQUIRE_CALL(*mock2, get_name())
         .RETURN(name2)
-        .TIMES(AT_LEAST(1));
+        .TIMES(1);
     REQUIRE_CALL(*mock2, enumerate_devices(ANY(std::vector<std::size_t>&)))
         .SIDE_EFFECT(_1 = {6, 7, 8, 9})
-        .TIMES(AT_LEAST(1));
+        .TIMES(1);
 
     // Test
     device_manager manager;

--- a/tests/unitary/src/compute/test_device_manager.cpp
+++ b/tests/unitary/src/compute/test_device_manager.cpp
@@ -43,13 +43,13 @@ class mock_device_backend final
     : public device_backend
 {
 public:
-    MAKE_MOCK(get_name, auto () -> const std::string&, const noexcept override);
-    MAKE_MOCK(get_version, auto () -> version, const noexcept override);
-    MAKE_MOCK(is_available, auto () -> bool, const noexcept override);
-    MAKE_MOCK(enumerate_devices, auto (std::vector<std::size_t>&) -> void, const override);
-    MAKE_MOCK(get_device_properties, auto (std::size_t, device_properties&) -> bool, const override);
-    MAKE_MOCK(create_device, auto (std::size_t) -> std::unique_ptr<device>, override);
-    MAKE_MOCK(create_device_shared, auto (std::size_t) -> std::shared_ptr<device>, override);
+    MAKE_MOCK0(get_name, const std::string& (), const noexcept override);
+    MAKE_MOCK0(get_version, version (), const noexcept override);
+    MAKE_MOCK0(is_available, bool (), const noexcept override);
+    MAKE_MOCK1(enumerate_devices, void (std::vector<std::size_t>&), const override);
+    MAKE_MOCK2(get_device_properties, bool (std::size_t, device_properties&), const override);
+    MAKE_MOCK1(create_device, std::unique_ptr<device> (std::size_t), override);
+    MAKE_MOCK1(create_device_shared, std::shared_ptr<device> (std::size_t), override);
 
 };
 

--- a/tests/unitary/src/compute/test_host_buffer.cpp
+++ b/tests/unitary/src/compute/test_host_buffer.cpp
@@ -60,27 +60,27 @@ TEST_CASE( "copy host buffer", "[host_buffer]" )
     mock_host_buffer src_buffer;
     REQUIRE_CALL(src_buffer, get_count())
         .RETURN(n)
-        .TIMES(AT_LEAST(1));
+        .TIMES(1);
     REQUIRE_CALL(src_buffer, get_type())
         .RETURN(numerical_type::int32)
-        .TIMES(AT_LEAST(1));
+        .TIMES(1);
     const mock_host_buffer &const_src_buffer = src_buffer;
     REQUIRE_CALL(const_src_buffer, get_data())
         .RETURN(src_ptr)
-        .TIMES(AT_LEAST(1));
+        .TIMES(1);
 
     std::vector<std::uint32_t> dst_data(n);
     void* dst_ptr = dst_data.data();
     mock_host_buffer dst_buffer;
     REQUIRE_CALL(dst_buffer, get_count())
         .RETURN(n)
-        .TIMES(AT_LEAST(1));
+        .TIMES(1);
     REQUIRE_CALL(dst_buffer, get_type())
         .RETURN(numerical_type::int32)
-        .TIMES(AT_LEAST(1));
+        .TIMES(1);
     REQUIRE_CALL(dst_buffer, get_data())
         .RETURN(dst_ptr)
-        .TIMES(AT_LEAST(1));
+        .TIMES(1);
 
     // populate
     for (std::size_t i = 0; i < n; ++i)
@@ -100,18 +100,14 @@ TEST_CASE( "copy host buffer", "[host_buffer]" )
 TEST_CASE( "copy host buffer with different type", "[host_buffer]" )
 {
     mock_host_buffer src;
-    ALLOW_CALL(src, get_count())
-        .RETURN(100);
     REQUIRE_CALL(src, get_type())
         .RETURN(numerical_type::int32)
-        .TIMES(AT_LEAST(1));
+        .TIMES(2);
 
     mock_host_buffer dst;
-    ALLOW_CALL(dst, get_count())
-        .RETURN(100);
     REQUIRE_CALL(dst, get_type())
         .RETURN(numerical_type::int16)
-        .TIMES(AT_LEAST(1));
+        .TIMES(2);
 
     REQUIRE_THROWS_AS( copy(src, dst), std::invalid_argument ); 
     REQUIRE_THROWS_WITH( copy(src, dst), "Both buffers must have the same numerical type" ); 
@@ -122,16 +118,18 @@ TEST_CASE( "copy host buffer with different size", "[host_buffer]" )
     mock_host_buffer src;
     REQUIRE_CALL(src, get_count())
         .RETURN(8)
-        .TIMES(AT_LEAST(1));
-    ALLOW_CALL(src, get_type())
-        .RETURN(numerical_type::int32);
+        .TIMES(2);
+    REQUIRE_CALL(src, get_type())
+        .RETURN(numerical_type::int32)
+        .TIMES(2);
 
     mock_host_buffer dst;
     REQUIRE_CALL(dst, get_count())
         .RETURN(10)
-        .TIMES(AT_LEAST(1));
-    ALLOW_CALL(dst, get_type())
-        .RETURN(numerical_type::int32);
+        .TIMES(2);
+    REQUIRE_CALL(dst, get_type())
+        .RETURN(numerical_type::int32)
+        .TIMES(2);
 
     REQUIRE_THROWS_AS( copy(src, dst), std::invalid_argument ); 
     REQUIRE_THROWS_WITH( copy(src, dst), "Both buffers must have the same element count" ); 
@@ -144,27 +142,27 @@ TEST_CASE( "copy host buffer regions", "[host_buffer]" )
     mock_host_buffer src_buffer;
     REQUIRE_CALL(src_buffer, get_count())
         .RETURN(1024)
-        .TIMES(AT_LEAST(1));
+        .TIMES(1);
     REQUIRE_CALL(src_buffer, get_type())
         .RETURN(numerical_type::int32)
-        .TIMES(AT_LEAST(1));
+        .TIMES(1);
     const mock_host_buffer &const_src_buffer = src_buffer;
     REQUIRE_CALL(const_src_buffer, get_data())
         .RETURN(src_ptr)
-        .TIMES(AT_LEAST(1));
+        .TIMES(1);
 
     std::vector<std::uint32_t> dst_data(2048);
     void* dst_ptr = dst_data.data();
     mock_host_buffer dst_buffer;
     REQUIRE_CALL(dst_buffer, get_count())
         .RETURN(2048)
-        .TIMES(AT_LEAST(1));
+        .TIMES(1);
     REQUIRE_CALL(dst_buffer, get_type())
         .RETURN(numerical_type::int32)
-        .TIMES(AT_LEAST(1));
+        .TIMES(1);
     REQUIRE_CALL(dst_buffer, get_data())
         .RETURN(dst_ptr)
-        .TIMES(AT_LEAST(1));
+        .TIMES(1);
 
     std::array<copy_region, 2> regions = {
         copy_region(512, 0, 512),
@@ -195,21 +193,25 @@ TEST_CASE( "copy out of bounds host buffer regions", "[host_buffer]" )
     mock_host_buffer src;
     REQUIRE_CALL(src, get_count())
         .RETURN(1024)
-        .TIMES(AT_LEAST(1));
-    ALLOW_CALL(src, get_type())
-        .RETURN(numerical_type::int32);
+        .TIMES(4);
+    REQUIRE_CALL(src, get_type())
+        .RETURN(numerical_type::int32)
+        .TIMES(4);
     const mock_host_buffer &const_src = src;
-    ALLOW_CALL(const_src, get_data())
-        .RETURN(nullptr);
+    REQUIRE_CALL(const_src, get_data())
+        .RETURN(nullptr)
+        .TIMES(4);
 
     mock_host_buffer dst;
     REQUIRE_CALL(dst, get_count())
         .RETURN(512)
-        .TIMES(AT_LEAST(1));
-    ALLOW_CALL(dst, get_type())
-        .RETURN(numerical_type::int32);
-    ALLOW_CALL(dst, get_data())
-        .RETURN(nullptr);
+        .TIMES(4);
+    REQUIRE_CALL(dst, get_type())
+        .RETURN(numerical_type::int32)
+        .TIMES(4);
+    REQUIRE_CALL(dst, get_data())
+        .RETURN(nullptr)
+        .TIMES(4);
 
     std::array<copy_region, 1> regions;
     
@@ -229,18 +231,14 @@ TEST_CASE( "copy out of bounds host buffer regions", "[host_buffer]" )
 TEST_CASE( "copy host buffer regions with different type", "[host_buffer]" )
 {
     mock_host_buffer src;
-    ALLOW_CALL(src, get_count())
-        .RETURN(256);
     REQUIRE_CALL(src, get_type())
         .RETURN(numerical_type::int32)
-        .TIMES(AT_LEAST(1));
+        .TIMES(2);
 
     mock_host_buffer dst;
-    ALLOW_CALL(dst, get_count())
-        .RETURN(128);
     REQUIRE_CALL(dst, get_type())
         .RETURN(numerical_type::int16)
-        .TIMES(AT_LEAST(1));
+        .TIMES(2);
 
     std::array<copy_region, 1> regions = {
         copy_region(16, 32, 64),

--- a/tests/unitary/src/compute/test_host_buffer.cpp
+++ b/tests/unitary/src/compute/test_host_buffer.cpp
@@ -42,10 +42,10 @@ class mock_host_buffer final
     : public host_buffer
 {
 public:
-    MAKE_MOCK(get_type, auto () -> numerical_type, const noexcept override);
-    MAKE_MOCK(get_count, auto () -> std::size_t, const noexcept override);
-    MAKE_MOCK(get_data, auto () -> void*, noexcept override);
-    MAKE_CONST_MOCK(get_data, auto () -> const void*, noexcept override);
+    MAKE_MOCK0(get_type, numerical_type (), const noexcept override);
+    MAKE_MOCK0(get_count, std::size_t (), const noexcept override);
+    MAKE_MOCK0(get_data, void* (), noexcept override);
+    MAKE_CONST_MOCK0(get_data, const void* (), noexcept override);
 
 };
 

--- a/tests/unitary/src/compute/test_host_buffer.cpp
+++ b/tests/unitary/src/compute/test_host_buffer.cpp
@@ -32,42 +32,20 @@
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers.hpp>
+#include <trompeloeil.hpp>
 
 
 using namespace xmipp4;
 using namespace xmipp4::compute;
 
-class test_host_buffer final
+class mock_host_buffer final
     : public host_buffer
 {
 public:
-    test_host_buffer(std::size_t n)
-        : m_data(n)
-    {
-    }
-
-    numerical_type get_type() const noexcept final
-    {
-        return numerical_type::int32;
-    }
-
-    std::size_t get_count() const noexcept final
-    {
-        return m_data.size();
-    }
-
-    void* get_data() noexcept final
-    {
-        return m_data.data();
-    }
-
-    const void* get_data() const noexcept final
-    {
-        return m_data.data();
-    }
-
-private:
-    std::vector<std::int32_t> m_data;
+    MAKE_MOCK(get_type, auto () -> numerical_type, const noexcept override);
+    MAKE_MOCK(get_count, auto () -> std::size_t, const noexcept override);
+    MAKE_MOCK(get_data, auto () -> void*, noexcept override);
+    MAKE_CONST_MOCK(get_data, auto () -> const void*, noexcept override);
 
 };
 
@@ -76,10 +54,32 @@ private:
 TEST_CASE( "copy host buffer", "[host_buffer]" )
 {
     const std::size_t n = 1024;
-    test_host_buffer src(n);   
-    test_host_buffer dst(n);
-    auto* src_data = static_cast<std::uint32_t*>(src.get_data());
-    auto* dst_data = static_cast<std::uint32_t*>(dst.get_data());
+
+    std::vector<std::uint32_t> src_data(n);
+    const void* src_ptr = src_data.data();
+    mock_host_buffer src_buffer;
+    REQUIRE_CALL(src_buffer, get_count())
+        .RETURN(n)
+        .TIMES(AT_LEAST(1));
+    REQUIRE_CALL(src_buffer, get_type())
+        .RETURN(numerical_type::int32)
+        .TIMES(AT_LEAST(1));
+    REQUIRE_CALL(const_cast<const mock_host_buffer&>(src_buffer), get_data())
+        .RETURN(src_ptr)
+        .TIMES(AT_LEAST(1));
+
+    std::vector<std::uint32_t> dst_data(n);
+    void* dst_ptr = dst_data.data();
+    mock_host_buffer dst_buffer;
+    REQUIRE_CALL(dst_buffer, get_count())
+        .RETURN(n)
+        .TIMES(AT_LEAST(1));
+    REQUIRE_CALL(dst_buffer, get_type())
+        .RETURN(numerical_type::int32)
+        .TIMES(AT_LEAST(1));
+    REQUIRE_CALL(dst_buffer, get_data())
+        .RETURN(dst_ptr)
+        .TIMES(AT_LEAST(1));
 
     // populate
     for (std::size_t i = 0; i < n; ++i)
@@ -87,7 +87,7 @@ TEST_CASE( "copy host buffer", "[host_buffer]" )
         src_data[i] = i*i + 2*i + 1;
     }
 
-    copy(src, dst);
+    copy(src_buffer, dst_buffer);
 
     // check
     for (std::size_t i = 0; i < n; ++i)
@@ -96,10 +96,41 @@ TEST_CASE( "copy host buffer", "[host_buffer]" )
     }
 }
 
+TEST_CASE( "copy host buffer with different type", "[host_buffer]" )
+{
+    mock_host_buffer src;
+    ALLOW_CALL(src, get_count())
+        .RETURN(100);
+    REQUIRE_CALL(src, get_type())
+        .RETURN(numerical_type::int32)
+        .TIMES(AT_LEAST(1));
+
+    mock_host_buffer dst;
+    ALLOW_CALL(dst, get_count())
+        .RETURN(100);
+    REQUIRE_CALL(dst, get_type())
+        .RETURN(numerical_type::int16)
+        .TIMES(AT_LEAST(1));
+
+    REQUIRE_THROWS_AS( copy(src, dst), std::invalid_argument ); 
+    REQUIRE_THROWS_WITH( copy(src, dst), "Both buffers must have the same numerical type" ); 
+}
+
 TEST_CASE( "copy host buffer with different size", "[host_buffer]" )
 {
-    test_host_buffer src(1024);   
-    test_host_buffer dst(8);
+    mock_host_buffer src;
+    REQUIRE_CALL(src, get_count())
+        .RETURN(8)
+        .TIMES(AT_LEAST(1));
+    ALLOW_CALL(src, get_type())
+        .RETURN(numerical_type::int32);
+
+    mock_host_buffer dst;
+    REQUIRE_CALL(dst, get_count())
+        .RETURN(10)
+        .TIMES(AT_LEAST(1));
+    ALLOW_CALL(dst, get_type())
+        .RETURN(numerical_type::int32);
 
     REQUIRE_THROWS_AS( copy(src, dst), std::invalid_argument ); 
     REQUIRE_THROWS_WITH( copy(src, dst), "Both buffers must have the same element count" ); 
@@ -107,10 +138,32 @@ TEST_CASE( "copy host buffer with different size", "[host_buffer]" )
 
 TEST_CASE( "copy host buffer regions", "[host_buffer]" )
 {
-    test_host_buffer src(1024);   
-    test_host_buffer dst(2048);
-    auto* src_data = static_cast<std::uint32_t*>(src.get_data());
-    auto* dst_data = static_cast<std::uint32_t*>(dst.get_data());
+    std::vector<std::uint32_t> src_data(1024);
+    const void* src_ptr = src_data.data();
+    mock_host_buffer src_buffer;
+    REQUIRE_CALL(src_buffer, get_count())
+        .RETURN(1024)
+        .TIMES(AT_LEAST(1));
+    REQUIRE_CALL(src_buffer, get_type())
+        .RETURN(numerical_type::int32)
+        .TIMES(AT_LEAST(1));
+    REQUIRE_CALL(const_cast<const mock_host_buffer&>(src_buffer), get_data())
+        .RETURN(src_ptr)
+        .TIMES(AT_LEAST(1));
+
+    std::vector<std::uint32_t> dst_data(2048);
+    void* dst_ptr = dst_data.data();
+    mock_host_buffer dst_buffer;
+    REQUIRE_CALL(dst_buffer, get_count())
+        .RETURN(2048)
+        .TIMES(AT_LEAST(1));
+    REQUIRE_CALL(dst_buffer, get_type())
+        .RETURN(numerical_type::int32)
+        .TIMES(AT_LEAST(1));
+    REQUIRE_CALL(dst_buffer, get_data())
+        .RETURN(dst_ptr)
+        .TIMES(AT_LEAST(1));
+
     std::array<copy_region, 2> regions = {
         copy_region(512, 0, 512),
         copy_region(0, 1536, 512),
@@ -122,7 +175,7 @@ TEST_CASE( "copy host buffer regions", "[host_buffer]" )
         src_data[i] = 4*i*i + i + 2;
     }
 
-    copy(src, dst, make_span(regions));
+    copy(src_buffer, dst_buffer, make_span(regions));
 
     // check
     for (std::size_t i = 0; i < 512; ++i)
@@ -137,8 +190,23 @@ TEST_CASE( "copy host buffer regions", "[host_buffer]" )
 
 TEST_CASE( "copy out of bounds host buffer regions", "[host_buffer]" )
 {
-    test_host_buffer src(1024);   
-    test_host_buffer dst(512);
+    mock_host_buffer src;
+    REQUIRE_CALL(src, get_count())
+        .RETURN(1024)
+        .TIMES(AT_LEAST(1));
+    ALLOW_CALL(src, get_type())
+        .RETURN(numerical_type::int32);
+    ALLOW_CALL(const_cast<const mock_host_buffer&>(src), get_data())
+        .RETURN(nullptr);
+
+    mock_host_buffer dst;
+    REQUIRE_CALL(dst, get_count())
+        .RETURN(512)
+        .TIMES(AT_LEAST(1));
+    ALLOW_CALL(dst, get_type())
+        .RETURN(numerical_type::int32);
+    ALLOW_CALL(dst, get_data())
+        .RETURN(nullptr);
 
     std::array<copy_region, 1> regions;
     
@@ -153,4 +221,28 @@ TEST_CASE( "copy out of bounds host buffer regions", "[host_buffer]" )
     };
     REQUIRE_THROWS_AS( copy(src, dst, make_span(regions)), std::out_of_range ); 
     REQUIRE_THROWS_WITH( copy(src, dst, make_span(regions)), "Destination region must be within buffer bounds" ); 
+}
+
+TEST_CASE( "copy host buffer regions with different type", "[host_buffer]" )
+{
+    mock_host_buffer src;
+    ALLOW_CALL(src, get_count())
+        .RETURN(256);
+    REQUIRE_CALL(src, get_type())
+        .RETURN(numerical_type::int32)
+        .TIMES(AT_LEAST(1));
+
+    mock_host_buffer dst;
+    ALLOW_CALL(dst, get_count())
+        .RETURN(128);
+    REQUIRE_CALL(dst, get_type())
+        .RETURN(numerical_type::int16)
+        .TIMES(AT_LEAST(1));
+
+    std::array<copy_region, 1> regions = {
+        copy_region(16, 32, 64),
+    };
+
+    REQUIRE_THROWS_AS( copy(src, dst, make_span(regions)), std::invalid_argument ); 
+    REQUIRE_THROWS_WITH( copy(src, dst, make_span(regions)), "Both buffers must have the same numerical type" ); 
 }

--- a/tests/unitary/src/compute/test_host_buffer.cpp
+++ b/tests/unitary/src/compute/test_host_buffer.cpp
@@ -64,7 +64,8 @@ TEST_CASE( "copy host buffer", "[host_buffer]" )
     REQUIRE_CALL(src_buffer, get_type())
         .RETURN(numerical_type::int32)
         .TIMES(AT_LEAST(1));
-    REQUIRE_CALL(const_cast<const mock_host_buffer&>(src_buffer), get_data())
+    const mock_host_buffer &const_src_buffer = src_buffer;
+    REQUIRE_CALL(const_src_buffer, get_data())
         .RETURN(src_ptr)
         .TIMES(AT_LEAST(1));
 
@@ -147,7 +148,8 @@ TEST_CASE( "copy host buffer regions", "[host_buffer]" )
     REQUIRE_CALL(src_buffer, get_type())
         .RETURN(numerical_type::int32)
         .TIMES(AT_LEAST(1));
-    REQUIRE_CALL(const_cast<const mock_host_buffer&>(src_buffer), get_data())
+    const mock_host_buffer &const_src_buffer = src_buffer;
+    REQUIRE_CALL(const_src_buffer, get_data())
         .RETURN(src_ptr)
         .TIMES(AT_LEAST(1));
 
@@ -196,7 +198,8 @@ TEST_CASE( "copy out of bounds host buffer regions", "[host_buffer]" )
         .TIMES(AT_LEAST(1));
     ALLOW_CALL(src, get_type())
         .RETURN(numerical_type::int32);
-    ALLOW_CALL(const_cast<const mock_host_buffer&>(src), get_data())
+    const mock_host_buffer &const_src = src;
+    ALLOW_CALL(const_src, get_data())
         .RETURN(nullptr);
 
     mock_host_buffer dst;

--- a/tests/unitary/src/test_interface_registry.cpp
+++ b/tests/unitary/src/test_interface_registry.cpp
@@ -26,15 +26,15 @@
  * 
  */
 
-#include <catch2/catch_test_macros.hpp>
-
 #include <xmipp4/core/interface_registry.hpp>
+
+#include <catch2/catch_test_macros.hpp>
 
 using namespace xmipp4;
 
-static const char sample_message[] = "Hi, I am a dummy interface manager";
+static const char sample_message[] = "Hi, I am a mock interface manager";
 
-class dummy_interface_manager
+class mock_interface_manager
     : public interface_manager
 {
 public:
@@ -46,10 +46,10 @@ TEST_CASE( "get interface manager", "[interface_registry]" )
 {
     interface_registry registry;
 
-    auto& manager1 = registry.get_interface_manager<dummy_interface_manager>();
+    auto& manager1 = registry.get_interface_manager<mock_interface_manager>();
     manager1.message = sample_message;
 
-    auto& manager2 = registry.get_interface_manager<dummy_interface_manager>();
+    auto& manager2 = registry.get_interface_manager<mock_interface_manager>();
     REQUIRE( &manager1 == &manager2 );
     REQUIRE( manager2.message == sample_message );
 }


### PR DESCRIPTION
We have adopted trompeloeil mocking library for mocking interfaces in tests. This PR includes the following modifications:

- Download trompeloeil in CMake
- Adapt existing tests that necessitate from mocking