### PR TITLE
Created dummy communicator

### DIFF
--- a/include/xmipp4/core/communication/dummy/dummy_communicator.hpp
+++ b/include/xmipp4/core/communication/dummy/dummy_communicator.hpp
@@ -85,6 +85,9 @@ public:
     void all_to_all(span<const T> send_buf, span<T> recv_buf) final;
 
 private:
+    void dummy_collective_operation(int root, 
+                                    span<const T> send_buf, 
+                                    span<T> recv_buf );
     void dummy_collective_operation(span<const T> send_buf, span<T> recv_buf);
 
 };

--- a/include/xmipp4/core/communication/dummy/dummy_communicator.hpp
+++ b/include/xmipp4/core/communication/dummy/dummy_communicator.hpp
@@ -1,0 +1,137 @@
+#pragma once
+
+/***************************************************************************
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+ * 02111-1307  USA
+ *
+ *  All comments concerning this program package may be sent to the
+ *  e-mail address 'xmipp@cnb.csic.es'
+ ***************************************************************************/
+
+/**
+ * @file dummy_communicator.hpp
+ * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
+ * @brief Definition of the communication::dummy_communicator class
+ * @date 2024-10-26
+ * 
+ */
+
+#include "../communicator.hpp"
+
+#include <memory>
+
+namespace xmipp4 
+{
+namespace communication
+{
+
+namespace detail
+{
+
+template<typename... Ts>
+class dummy_communicator_helper;
+
+template<typename T, typename... Ts>
+class dummy_communicator_helper<T, Ts...>
+    : public dummy_communicator_helper<Ts...>
+{
+public:
+    using dummy_communicator_helper<Ts...>::send;
+    using dummy_communicator_helper<Ts...>::receive;
+    using dummy_communicator_helper<Ts...>::send_receive;
+    using dummy_communicator_helper<Ts...>::broadcast;
+    using dummy_communicator_helper<Ts...>::scatter;
+    using dummy_communicator_helper<Ts...>::gather;
+    using dummy_communicator_helper<Ts...>::all_gather;
+    using dummy_communicator_helper<Ts...>::reduce;
+    using dummy_communicator_helper<Ts...>::all_reduce;
+    using dummy_communicator_helper<Ts...>::all_to_all;
+
+    void send(int destination_rank, span<const T> buf) final;
+
+    std::size_t receive(int source_rank, span<T> buf) final;
+
+    std::size_t send_receive(int destination_rank, span<const T> send_buf,
+                             int source_rank, span<T> receive_buf ) final;
+
+    void broadcast(int root, span<T> buf) final;
+
+    void scatter(int root, 
+                 span<const T> send_buf, span<T> recv_buf ) final;
+
+    void gather(int root, 
+                span<const T> send_buf, span<T> recv_buf ) final;
+
+    void all_gather(span<const T> send_buf, span<T> recv_buf) final;
+
+    void reduce(int root, reduction_operation op,
+                span<const T> send_buf, span<T> recv_buf ) final;
+
+    void all_reduce(reduction_operation op,
+                    span<const T> send_buf, span<T> recv_buf ) final;
+
+    void all_to_all(span<const T> send_buf, span<T> recv_buf) final;
+
+private:
+    void dummy_collective_operation(span<const T> send_buf, span<T> recv_buf);
+
+};
+
+template<>
+class dummy_communicator_helper<>
+    : public communicator
+{
+};
+
+} // namespace detail
+
+
+
+
+
+class dummy_communicator final
+    : public detail::dummy_communicator_helper<memory::byte,
+                                               char,
+                                               signed char,
+                                               unsigned char,
+                                               short,
+                                               unsigned short,
+                                               int,
+                                               unsigned int,
+                                               long,
+                                               unsigned long,
+                                               long long,
+                                               unsigned long long,
+                                               float,
+                                               double,
+                                               long double>
+{
+public:
+    std::size_t get_size() const override;
+
+    int get_rank() const override;
+
+    std::unique_ptr<communicator> split(int colour, 
+                                        int rank_priority ) const override;
+
+    std::shared_ptr<communicator> split_shared(int colour, 
+                                               int rank_priority ) const override;
+
+    void barrier() override;
+
+};
+
+} // namespace communication
+} // namespace xmipp4

--- a/include/xmipp4/core/communication/dummy/dummy_communicator_backend.hpp
+++ b/include/xmipp4/core/communication/dummy/dummy_communicator_backend.hpp
@@ -1,0 +1,56 @@
+#pragma once
+
+/***************************************************************************
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+ * 02111-1307  USA
+ *
+ *  All comments concerning this program package may be sent to the
+ *  e-mail address 'xmipp@cnb.csic.es'
+ ***************************************************************************/
+
+/**
+ * @file dummy_communicator_backend.hpp
+ * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
+ * @brief Definition of the communication::dummy_communicator_backend class
+ * @date 2024-11-20
+ * 
+ */
+
+#include "../communicator_backend.hpp"
+
+#include <memory>
+
+namespace xmipp4 
+{
+namespace communication
+{
+
+class communicator_manager;
+
+class dummy_communicator_backend final
+    : public communicator_backend
+{
+public:
+    const std::string& get_name() const noexcept override;
+    version get_version() const noexcept override;
+    bool is_available() const noexcept override;
+    std::shared_ptr<communicator> get_world_communicator() const override;
+
+    static bool register_at(communicator_manager &manager);
+
+};
+
+} // namespace communication
+} // namespace xmipp4

--- a/src/communication/dummy/dummy_communicator.cpp
+++ b/src/communication/dummy/dummy_communicator.cpp
@@ -1,0 +1,196 @@
+/***************************************************************************
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+ * 02111-1307  USA
+ *
+ *  All comments concerning this program package may be sent to the
+ *  e-mail address 'xmipp@cnb.csic.es'
+ ***************************************************************************/
+
+/**
+ * @file dummy_communicator.cpp
+ * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
+ * @brief Implementation of dummy_communicator.hpp
+ * @date 2024-11-20
+ * 
+ */
+
+#include <xmipp4/core/communication/dummy/dummy_communicator.hpp>
+
+#include <stdexcept>
+#include <algorithm>
+
+namespace xmipp4 
+{
+namespace communication
+{
+namespace detail
+{
+
+static void require_root_0(int root)
+{
+    if (root != 0)
+    {
+        throw std::invalid_argument(
+            "invalid root specified"
+        );
+    }
+}
+
+static std::size_t require_same_count(std::size_t send_count, 
+                                      std::size_t recv_count )
+{
+    if (send_count != recv_count)
+    {
+        throw std::invalid_argument(
+            "send and receive buffer sizes must match"
+        );
+    }
+
+    return send_count;
+}
+
+template<typename T, typename... Ts>
+void dummy_communicator_helper<T, Ts...>::send(int, span<const T>)
+{
+    throw std::logic_error("send cannot be called with a single rank");
+}
+
+template<typename T, typename... Ts>
+std::size_t 
+dummy_communicator_helper<T, Ts...>::receive(int, span<T>)
+{
+    throw std::logic_error("receive cannot be called with a single rank");
+}
+
+template<typename T, typename... Ts>
+std::size_t 
+dummy_communicator_helper<T, Ts...>::send_receive(int,
+                                                  span<const T>,
+                                                  int, 
+                                                  span<T> )
+{
+    throw std::logic_error("send_receive cannot be called with a single rank");
+}
+
+template<typename T, typename... Ts>
+void dummy_communicator_helper<T, Ts...>::broadcast(int root, span<T>)
+{
+    require_root_0(root);
+    // No-op
+}
+
+template<typename T, typename... Ts>
+void dummy_communicator_helper<T, Ts...>::scatter(int root, 
+                                                  span<const T> send_buf, 
+                                                  span<T> recv_buf )
+{
+    require_root_0(root);
+    dummy_collective_operation(send_buf, recv_buf);
+}
+
+template<typename T, typename... Ts>
+void dummy_communicator_helper<T, Ts...>::gather(int root, 
+                                                 span<const T> send_buf, 
+                                                 span<T> recv_buf )
+{
+    require_root_0(root);
+    dummy_collective_operation(send_buf, recv_buf);
+}
+
+template<typename T, typename... Ts>
+void dummy_communicator_helper<T, Ts...>::all_gather(span<const T> send_buf, 
+                                                     span<T> recv_buf )
+{
+    dummy_collective_operation(send_buf, recv_buf);
+}
+
+template<typename T, typename... Ts>
+void dummy_communicator_helper<T, Ts...>::reduce(int root, 
+                                                 reduction_operation,
+                                                 span<const T> send_buf, 
+                                                 span<T> recv_buf )
+{
+    require_root_0(root);
+    dummy_collective_operation(send_buf, recv_buf);
+}
+
+template<typename T, typename... Ts>
+void dummy_communicator_helper<T, Ts...>::all_reduce(reduction_operation,
+                                                     span<const T> send_buf, 
+                                                     span<T> recv_buf )
+{
+    dummy_collective_operation(send_buf, recv_buf);
+}
+
+template<typename T, typename... Ts>
+void dummy_communicator_helper<T, Ts...>::all_to_all(span<const T> send_buf, 
+                                                     span<T> recv_buf )
+{
+    dummy_collective_operation(send_buf, recv_buf);
+}
+
+template<typename T, typename... Ts>
+void dummy_communicator_helper<T, Ts...>::dummy_collective_operation(span<const T> send_buf, 
+                                                                     span<T> recv_buf )
+{
+    const auto count = require_same_count(send_buf.size(), recv_buf.size());
+
+    // In case it is not an alias, perform a plain copy.
+    if(send_buf.data() != recv_buf.data())
+    {
+        std::copy_n(
+            send_buf.data(),
+            count,
+            recv_buf.data()
+        );
+    }
+}
+
+} // namespace detail
+
+
+
+
+
+std::size_t dummy_communicator::get_size() const
+{
+    return 1;
+}
+
+int dummy_communicator::get_rank() const
+{
+    return 0;
+}
+
+std::unique_ptr<communicator> 
+dummy_communicator::split(int, int) const
+{
+    return std::make_unique<dummy_communicator>();
+}
+
+std::shared_ptr<communicator> 
+dummy_communicator::split_shared(int, int) const
+{
+    return std::make_shared<dummy_communicator>();
+}
+
+
+void dummy_communicator::barrier()
+{
+    // No-op
+}
+
+} // namespace communication
+} // namespace xmipp4

--- a/src/communication/dummy/dummy_communicator.cpp
+++ b/src/communication/dummy/dummy_communicator.cpp
@@ -64,14 +64,14 @@ static std::size_t require_same_count(std::size_t send_count,
 template<typename T, typename... Ts>
 void dummy_communicator_helper<T, Ts...>::send(int, span<const T>)
 {
-    throw std::logic_error("send cannot be called with a single rank");
+    throw std::domain_error("send cannot be called with a single rank");
 }
 
 template<typename T, typename... Ts>
 std::size_t 
 dummy_communicator_helper<T, Ts...>::receive(int, span<T>)
 {
-    throw std::logic_error("receive cannot be called with a single rank");
+    throw std::domain_error("receive cannot be called with a single rank");
 }
 
 template<typename T, typename... Ts>
@@ -81,7 +81,7 @@ dummy_communicator_helper<T, Ts...>::send_receive(int,
                                                   int, 
                                                   span<T> )
 {
-    throw std::logic_error("send_receive cannot be called with a single rank");
+    throw std::domain_error("send_receive cannot be called with a single rank");
 }
 
 template<typename T, typename... Ts>

--- a/src/communication/dummy/dummy_communicator.cpp
+++ b/src/communication/dummy/dummy_communicator.cpp
@@ -96,8 +96,7 @@ void dummy_communicator_helper<T, Ts...>::scatter(int root,
                                                   span<const T> send_buf, 
                                                   span<T> recv_buf )
 {
-    require_root_0(root);
-    dummy_collective_operation(send_buf, recv_buf);
+    dummy_collective_operation(root, send_buf, recv_buf);
 }
 
 template<typename T, typename... Ts>
@@ -106,7 +105,7 @@ void dummy_communicator_helper<T, Ts...>::gather(int root,
                                                  span<T> recv_buf )
 {
     require_root_0(root);
-    dummy_collective_operation(send_buf, recv_buf);
+    dummy_collective_operation(root, send_buf, recv_buf);
 }
 
 template<typename T, typename... Ts>
@@ -138,6 +137,15 @@ template<typename T, typename... Ts>
 void dummy_communicator_helper<T, Ts...>::all_to_all(span<const T> send_buf, 
                                                      span<T> recv_buf )
 {
+    dummy_collective_operation(send_buf, recv_buf);
+}
+
+template<typename T, typename... Ts>
+void dummy_communicator_helper<T, Ts...>::dummy_collective_operation(int root,
+                                                                     span<const T> send_buf, 
+                                                                     span<T> recv_buf )
+{
+    require_root_0(root);
     dummy_collective_operation(send_buf, recv_buf);
 }
 

--- a/src/communication/dummy/dummy_communicator_backend.cpp
+++ b/src/communication/dummy/dummy_communicator_backend.cpp
@@ -1,0 +1,72 @@
+/***************************************************************************
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+ * 02111-1307  USA
+ *
+ *  All comments concerning this program package may be sent to the
+ *  e-mail address 'xmipp@cnb.csic.es'
+ ***************************************************************************/
+
+/**
+ * @file dummy_communicator_backend.cpp
+ * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
+ * @brief Implementation of dummy_communicator_backend.hpp
+ * @date 2024-10-26
+ * 
+ */
+
+#include <xmipp4/core/communication/dummy/dummy_communicator_backend.hpp>
+
+#include <xmipp4/core/communication/dummy/dummy_communicator.hpp>
+#include <xmipp4/core/communication/communicator_manager.hpp>
+
+#include <xmipp4/core/core_version.hpp>
+
+namespace xmipp4 
+{
+namespace communication
+{
+
+static const std::string name = "dummy";
+
+const std::string& dummy_communicator_backend::get_name() const noexcept
+{
+    return name;
+}
+
+version dummy_communicator_backend::get_version() const noexcept
+{
+    return get_core_version();
+}
+
+bool dummy_communicator_backend::is_available() const noexcept
+{
+    return true;
+}
+
+std::shared_ptr<communicator> 
+dummy_communicator_backend::get_world_communicator() const
+{
+    return std::make_shared<dummy_communicator>();
+}
+
+bool dummy_communicator_backend::register_at(communicator_manager &manager)
+{
+    return manager.register_backend(
+        std::make_unique<dummy_communicator_backend>()
+    );
+}
+
+} // namespace communication
+} // namespace xmipp4


### PR DESCRIPTION
Dummy communicator to used when a "real" communicator such as MPI is not available. It mocks a single rank communicator, such that most operations are no-ops or copies.