### PR TITLE
Group non-major version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      # Group all non-major updates into a single Pull Request
+      minor-and-patch:
+        applies-to: version-updates
+        update-types:
+        - "minor"
+        - "patch"


### PR DESCRIPTION
This will avoid over-generation of automatic Pull Requests, while still keeping the major version updates separate to test them individually.