### PR TITLE
Rename synchronize to wait_until_completed

### DIFF
--- a/include/xmipp4/core/compute/device_queue.hpp
+++ b/include/xmipp4/core/compute/device_queue.hpp
@@ -54,7 +54,7 @@ public:
      * @brief Wait until the device_queue is flushed.
      * 
      */
-    virtual void synchronize() const = 0;
+    virtual void wait_until_completed() const = 0;
 
 }; 
 

--- a/include/xmipp4/core/compute/host/host_device_queue.hpp
+++ b/include/xmipp4/core/compute/host/host_device_queue.hpp
@@ -44,7 +44,7 @@ class host_device_queue final
     : public device_queue
 {
 public:
-    void synchronize() const override;
+    void wait_until_completed() const override;
 
 }; 
 

--- a/src/compute/host/host_device_queue.cpp
+++ b/src/compute/host/host_device_queue.cpp
@@ -33,7 +33,7 @@ namespace xmipp4
 namespace compute
 {
 
-void host_device_queue::synchronize() const
+void host_device_queue::wait_until_completed() const
 {
     // NO-OP
 }


### PR DESCRIPTION
More explicit naming of method. Closes #96 