### PR TITLE
Added buffer aliasing methods

### DIFF
--- a/include/xmipp4/core/compute/device_buffer.hpp
+++ b/include/xmipp4/core/compute/device_buffer.hpp
@@ -38,6 +38,8 @@ namespace xmipp4
 namespace compute
 {
 
+class host_buffer;
+
 /**
  * @brief Abstract class defining an in-device memory
  * allocation.
@@ -71,6 +73,24 @@ public:
      * 
      */
     virtual std::size_t get_count() const noexcept = 0;
+
+    /**
+     * @brief Get a host accessible alias of this buffer.
+     * 
+     * If this buffer is not host accessible, this method returns null.
+     * 
+     * @return host_buffer* Host accessible alias of this buffer.
+     */
+    virtual host_buffer* get_host_accessible_alias() noexcept = 0;
+
+    /**
+     * @brief Get a host accessible alias of this buffer.
+     * 
+     * If this buffer is not host accessible, this method returns null.
+     * 
+     * @return const host_buffer* Host accessible alias of this buffer.
+     */
+    virtual const host_buffer* get_host_accessible_alias() const noexcept = 0;
 
 }; 
 

--- a/include/xmipp4/core/compute/host_buffer.hpp
+++ b/include/xmipp4/core/compute/host_buffer.hpp
@@ -40,6 +40,8 @@ namespace xmipp4
 namespace compute
 {
 
+class device_buffer;
+
 /**
  * @brief Abstract class defining an in-host memory
  * allocation.
@@ -87,6 +89,26 @@ public:
      * @return const void* The data.
      */
     virtual const void* get_data() const noexcept = 0;
+
+    /**
+     * @brief Get a device accessible alias of this buffer.
+     * 
+     * If this buffer is not device accessible, this method returns null.
+     * 
+     * @return device_buffer* Device accessible alias of this buffer.
+     * 
+     */
+    virtual device_buffer* get_device_accessible_alias() noexcept = 0;
+
+    /**
+     * @brief Get a device accessible alias of this buffer.
+     * 
+     * If this buffer is not device accessible, this method returns null.
+     * 
+     * @return const device_buffer* Device accessible alias of this buffer.
+     */
+    virtual 
+    const device_buffer* get_device_accessible_alias() const noexcept = 0;
 
 };
 

--- a/src/compute/host/host_unified_buffer.cpp
+++ b/src/compute/host/host_unified_buffer.cpp
@@ -1,5 +1,3 @@
-#pragma once
-
 /***************************************************************************
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -21,45 +19,41 @@
  ***************************************************************************/
 
 /**
- * @file host_unified_buffer.hpp
+ * @file host_unified_buffer.cpp
  * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Defines the compute::host_unified_buffer interface
- * @date 2024-10-29
+ * @brief Implementation of default_host_unified_buffer.hpp
+ * @date 2024-11-26
  * 
  */
 
-#include "../device_buffer.hpp"
-#include "../host_buffer.hpp"
+#include <xmipp4/core/compute/host/host_unified_buffer.hpp>
 
-namespace xmipp4 
+namespace xmipp4
 {
 namespace compute
 {
 
-/**
- * @brief Interface merging the interfaces of host_buffer and device_buffer.
- * 
- * This interface unifies host_buffer and device_buffer interfaces, as
- * when using the host as a compute device, both buffers types are 
- * equivalent
- * 
- */
-class host_unified_buffer
-    : public device_buffer
-    , public host_buffer
+device_buffer* host_unified_buffer::get_device_accessible_alias() noexcept
 {
-public:
-    numerical_type get_type() const noexcept override = 0;
-    std::size_t get_count() const noexcept override = 0;
-    void* get_data() noexcept override = 0;
-    const void* get_data() const noexcept override = 0;
+    return this;
+}
 
-    device_buffer* get_device_accessible_alias() noexcept final;
-    const device_buffer* get_device_accessible_alias() const noexcept final;
-    host_buffer* get_host_accessible_alias() noexcept final;
-    const host_buffer* get_host_accessible_alias() const noexcept final;
+const device_buffer* 
+host_unified_buffer::get_device_accessible_alias() const noexcept
+{
+    return this;
+}
 
-}; 
+host_buffer* host_unified_buffer::get_host_accessible_alias() noexcept
+{
+    return this;
+}
+
+const host_buffer* 
+host_unified_buffer::get_host_accessible_alias() const noexcept
+{
+    return this;
+}
 
 } // namespace compute
 } // namespace xmipp4

--- a/tests/unitary/src/compute/test_host_buffer.cpp
+++ b/tests/unitary/src/compute/test_host_buffer.cpp
@@ -46,6 +46,8 @@ public:
     MAKE_MOCK0(get_count, std::size_t (), const noexcept override);
     MAKE_MOCK0(get_data, void* (), noexcept override);
     MAKE_CONST_MOCK0(get_data, const void* (), noexcept override);
+    MAKE_MOCK0(get_device_accessible_alias, device_buffer* (), noexcept override);
+    MAKE_CONST_MOCK0(get_device_accessible_alias, const device_buffer* (), noexcept override);
 
 };
 


### PR DESCRIPTION
For unified memory environments these method allows to obtain host/device aliases directly