### PR TITLE
Created device_queue_pool class

### DIFF
--- a/include/xmipp4/core/compute/device.hpp
+++ b/include/xmipp4/core/compute/device.hpp
@@ -37,7 +37,7 @@ namespace xmipp4
 namespace compute
 {
 
-class device_queue;
+class device_queue_pool;
 class device_memory_allocator;
 class host_memory_allocator;
 class device_to_host_transfer;
@@ -67,18 +67,11 @@ public:
     device& operator=(device &&other) = default;
 
     /**
-     * @brief Create a command queue for this device.
+     * @brief Get a reference to the queue pool.
      * 
-     * @return std::unique_ptr<device_queue> The queue.
+     * @return device_queue_pool& The queue pool.
      */
-    virtual std::unique_ptr<device_queue> create_queue() = 0;
-
-    /**
-     * @brief Create a command queue for this device.
-     * 
-     * @return std::shared_ptr<device_queue> The queue.
-     */
-    virtual std::shared_ptr<device_queue> create_queue_shared() = 0;
+    virtual device_queue_pool& get_queue_pool() = 0;
 
     /**
      * @brief Create a memory allocator for this device.

--- a/include/xmipp4/core/compute/device_queue.hpp
+++ b/include/xmipp4/core/compute/device_queue.hpp
@@ -56,6 +56,14 @@ public:
      */
     virtual void wait_until_completed() const = 0;
 
+    /**
+     * @brief Check if the queue has completed processing.
+     * 
+     * @return true Queue has finished processing.
+     * @return false Queue is busy processing.
+     */
+    virtual bool is_idle() const noexcept = 0;
+
 }; 
 
 } // namespace compute

--- a/include/xmipp4/core/compute/device_queue_pool.hpp
+++ b/include/xmipp4/core/compute/device_queue_pool.hpp
@@ -21,33 +21,44 @@
  ***************************************************************************/
 
 /**
- * @file host_device_queue.hpp
+ * @file device_queue_pool.hpp
  * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Defines host_device_queue interface
- * @date 2024-10-29
+ * @brief Defines the compute::device_queue_pool interface
+ * @date 2024-11-27
  * 
  */
 
-#include "../device_queue.hpp"
+#include "../platform/dynamic_shared_object.h"
+
+#include <cstddef>
 
 namespace xmipp4 
 {
 namespace compute
 {
 
+class device_queue;
+
 /**
- * @brief Special implementation of the device_queue interface to be 
- * able to send commands to the host.
+ * @brief Abstract class describing a pool of device_queues.
  * 
  */
-class host_device_queue final
-    : public device_queue
+class XMIPP4_CORE_API device_queue_pool
 {
 public:
-    void wait_until_completed() const override;
-    bool is_idle() const noexcept override;
+    device_queue_pool() = default;
+    device_queue_pool(const device_queue_pool &other) = default;
+    device_queue_pool(device_queue_pool &&other) = default;
+    virtual ~device_queue_pool() = default;
+
+    device_queue_pool& operator=(const device_queue_pool &other) = default;
+    device_queue_pool& operator=(device_queue_pool &&other) = default;
+
+    virtual std::size_t get_size() const noexcept = 0;
+    virtual device_queue& get_queue(std::size_t index) = 0;
 
 }; 
 
 } // namespace compute
 } // namespace xmipp4
+

--- a/include/xmipp4/core/compute/host/host_device.hpp
+++ b/include/xmipp4/core/compute/host/host_device.hpp
@@ -30,6 +30,8 @@
 
 #include "../device.hpp"
 
+#include "host_device_queue_pool.hpp"
+
 namespace xmipp4 
 {
 namespace compute
@@ -44,8 +46,7 @@ class host_device final
     : public device
 {
 public:
-    std::unique_ptr<device_queue> create_queue() override;
-    std::shared_ptr<device_queue> create_queue_shared() override;
+    host_device_queue_pool& get_queue_pool() override;
 
     std::unique_ptr<device_memory_allocator> 
     create_device_memory_allocator() override;
@@ -79,6 +80,9 @@ public:
     create_device_to_host_event() override;
     std::shared_ptr<device_to_host_event> 
     create_device_to_host_event_shared() override;
+
+private:
+    host_device_queue_pool m_queue_pool;
 
 }; 
 

--- a/include/xmipp4/core/compute/host/host_device_queue_pool.hpp
+++ b/include/xmipp4/core/compute/host/host_device_queue_pool.hpp
@@ -24,11 +24,13 @@
  * @file host_device_queue.hpp
  * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
  * @brief Defines host_device_queue interface
- * @date 2024-10-29
+ * @date 2024-11-27
  * 
  */
 
-#include "../device_queue.hpp"
+#include "../device_queue_pool.hpp"
+
+#include "host_device_queue.hpp"
 
 namespace xmipp4 
 {
@@ -36,16 +38,19 @@ namespace compute
 {
 
 /**
- * @brief Special implementation of the device_queue interface to be 
- * able to send commands to the host.
+ * @brief Special implementation of the device_queue_pool interface to be 
+ * able to obtain host device queues.
  * 
  */
-class host_device_queue final
-    : public device_queue
+class host_device_queue_pool final
+    : public device_queue_pool
 {
 public:
-    void wait_until_completed() const override;
-    bool is_idle() const noexcept override;
+    std::size_t get_size() const noexcept override;
+    host_device_queue& get_queue(std::size_t index) override;
+
+private:
+    host_device_queue m_queue;
 
 }; 
 

--- a/include/xmipp4/core/compute/host/host_device_queue_pool.hpp
+++ b/include/xmipp4/core/compute/host/host_device_queue_pool.hpp
@@ -38,8 +38,12 @@ namespace compute
 {
 
 /**
- * @brief Special implementation of the device_queue_pool interface to be 
- * able to obtain host device queues.
+ * @brief Implementation of the device_queue_pool interface to be 
+ * able to obtain host_device_queue-s.
+ * 
+ * As host_device_queue-s are synchronous, it does not make sense to
+ * instantiate multiple of them. Thus, this pool always has a size of
+ * one.
  * 
  */
 class host_device_queue_pool final

--- a/src/compute/host/host_device.cpp
+++ b/src/compute/host/host_device.cpp
@@ -38,14 +38,9 @@ namespace xmipp4
 namespace compute
 {
 
-std::unique_ptr<device_queue> host_device::create_queue()
+host_device_queue_pool& host_device::get_queue_pool()
 {
-    return std::make_unique<host_device_queue>();
-}
-
-std::shared_ptr<device_queue> host_device::create_queue_shared()
-{
-    return std::make_shared<host_device_queue>();
+    return m_queue_pool;
 }
 
 std::unique_ptr<device_memory_allocator> 

--- a/src/compute/host/host_device_queue.cpp
+++ b/src/compute/host/host_device_queue.cpp
@@ -38,5 +38,10 @@ void host_device_queue::wait_until_completed() const
     // NO-OP
 }
 
+bool host_device_queue::is_idle() const noexcept
+{
+    return true;
+}
+
 } // namespace compute
 } // namespace xmipp4

--- a/src/compute/host/host_device_queue_pool.cpp
+++ b/src/compute/host/host_device_queue_pool.cpp
@@ -1,5 +1,3 @@
-#pragma once
-
 /***************************************************************************
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -21,33 +19,39 @@
  ***************************************************************************/
 
 /**
- * @file host_device_queue.hpp
+ * @file host_device_queue_pool.cpp
  * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Defines host_device_queue interface
- * @date 2024-10-29
+ * @brief Implementation of host_device_queue_pool.hpp
+ * @date 2024-11-27
  * 
  */
 
-#include "../device_queue.hpp"
+#include <xmipp4/core/compute/host/host_device_queue_pool.hpp>
 
-namespace xmipp4 
+#include <stdexcept>
+
+namespace xmipp4
 {
 namespace compute
 {
 
-/**
- * @brief Special implementation of the device_queue interface to be 
- * able to send commands to the host.
- * 
- */
-class host_device_queue final
-    : public device_queue
-{
-public:
-    void wait_until_completed() const override;
-    bool is_idle() const noexcept override;
 
-}; 
+std::size_t host_device_queue_pool::get_size() const noexcept
+{
+    return 1;
+}
+
+host_device_queue& host_device_queue_pool::get_queue(std::size_t index)
+{
+    if (index > 0)
+    {
+        throw std::out_of_range(
+            "queue index is out of range"
+        );
+    }
+
+    return m_queue;
+}
 
 } // namespace compute
 } // namespace xmipp4


### PR DESCRIPTION
The device queue pool allows creating queues upfront instead of allocating them one by one. This approach is more restrictive but it adapts better to some backends. Additionally, the flexibility of creating new queues during execution does not provide any benefit in real scenarios.

Merge after https://github.com/gigabit-clowns/xmipp4-compute-cuda/pull/18