### PR TITLE
Enabled asynchronous semantics for host_memory_allocator

### DIFF
--- a/include/xmipp4/core/compute/device_buffer.hpp
+++ b/include/xmipp4/core/compute/device_buffer.hpp
@@ -97,6 +97,10 @@ public:
      * @brief Acknowledge that the buffer is being used in a queue other than
      * the one used for allocation.
      * 
+     * This will prevent premature deallocation before the provided queue
+     * has completed execution until the point where it can be safely 
+     * deallocated.
+     * 
      * @param queue The queue where the buffer is being used.
      * 
      */

--- a/include/xmipp4/core/compute/device_buffer.hpp
+++ b/include/xmipp4/core/compute/device_buffer.hpp
@@ -39,6 +39,7 @@ namespace compute
 {
 
 class host_buffer;
+class device_queue;
 
 /**
  * @brief Abstract class defining an in-device memory
@@ -91,6 +92,15 @@ public:
      * @return const host_buffer* Host accessible alias of this buffer.
      */
     virtual const host_buffer* get_host_accessible_alias() const noexcept = 0;
+
+    /**
+     * @brief Acknowledge that the buffer is being used in a queue other than
+     * the one used for allocation.
+     * 
+     * @param queue The queue where the buffer is being used.
+     * 
+     */
+    virtual void record_queue(device_queue &queue) = 0;
 
 }; 
 

--- a/include/xmipp4/core/compute/device_memory_allocator.hpp
+++ b/include/xmipp4/core/compute/device_memory_allocator.hpp
@@ -74,9 +74,9 @@ public:
      * synchronization.
      */
     virtual std::unique_ptr<device_buffer> 
-    create_buffer(numerical_type type, 
-                  std::size_t count, 
-                  device_queue &queue ) = 0;
+    create_device_buffer(numerical_type type, 
+                         std::size_t count, 
+                         device_queue &queue ) = 0;
 
     /**
      * @brief Allocate a buffer in this device.
@@ -91,9 +91,9 @@ public:
      * synchronization.
      */
     virtual std::shared_ptr<device_buffer> 
-    create_buffer_shared(numerical_type type, 
-                         std::size_t count, 
-                         device_queue &queue ) = 0;
+    create_device_buffer_shared(numerical_type type, 
+                                std::size_t count, 
+                                device_queue &queue ) = 0;
 
 }; 
 

--- a/include/xmipp4/core/compute/device_to_host_transfer.hpp
+++ b/include/xmipp4/core/compute/device_to_host_transfer.hpp
@@ -85,7 +85,7 @@ public:
      */
     virtual void
     transfer_copy(const device_buffer &src_buffer,
-                  const std::shared_ptr<host_buffer> &dst_buffer,
+                  host_buffer &dst_buffer,
                   device_queue &queue ) = 0;
 
     /**
@@ -112,7 +112,7 @@ public:
      */
     virtual void
     transfer_copy(const device_buffer &src_buffer,
-                  const std::shared_ptr<host_buffer> &dst_buffer,
+                  host_buffer &dst_buffer,
                   span<const copy_region> regions,
                   device_queue &queue ) = 0;
 

--- a/include/xmipp4/core/compute/device_to_host_transfer.hpp
+++ b/include/xmipp4/core/compute/device_to_host_transfer.hpp
@@ -158,12 +158,6 @@ public:
              host_memory_allocator &allocator,
              device_queue &queue ) = 0;
 
-    /**
-     * @brief Block the current thread until the transfers have finished.
-     * 
-     */
-    virtual void wait() = 0;
-
 }; 
 
 } // namespace compute

--- a/include/xmipp4/core/compute/host/host_transfer.hpp
+++ b/include/xmipp4/core/compute/host/host_transfer.hpp
@@ -100,9 +100,6 @@ public:
               span<const copy_region> regions,
               device_queue &queue ) override;
 
-    void wait() override;
-    void wait(device_queue &queue) override;
-
 }; 
 
 } // namespace compute

--- a/include/xmipp4/core/compute/host/host_transfer.hpp
+++ b/include/xmipp4/core/compute/host/host_transfer.hpp
@@ -53,11 +53,11 @@ class host_transfer final
     , public device_copy
 {
 public:
-    void transfer_copy(const std::shared_ptr<const host_buffer> &src_buffer,
+    void transfer_copy(const host_buffer &src_buffer,
                        device_buffer &dst_buffer, 
                        device_queue &queue ) override;
     
-    void transfer_copy(const std::shared_ptr<const host_buffer> &src_buffer,
+    void transfer_copy(const host_buffer &src_buffer,
                        device_buffer &dst_buffer, 
                        span<const copy_region> regions, 
                        device_queue &queue ) override;
@@ -73,11 +73,11 @@ public:
              device_queue &queue ) override;
 
     void transfer_copy(const device_buffer &src_buffer,
-                       const std::shared_ptr<host_buffer> &dst_buffer, 
+                       host_buffer &dst_buffer, 
                        device_queue &queue ) override;
 
     void transfer_copy(const device_buffer &src_buffer,
-                       const std::shared_ptr<host_buffer> &dst_buffer, 
+                       host_buffer &dst_buffer, 
                        span<const copy_region> regions, 
                        device_queue &queue ) override;
 

--- a/include/xmipp4/core/compute/host/host_unified_buffer.hpp
+++ b/include/xmipp4/core/compute/host/host_unified_buffer.hpp
@@ -58,6 +58,8 @@ public:
     const host_unified_buffer* get_device_accessible_alias() const noexcept final;
     host_unified_buffer* get_host_accessible_alias() noexcept final;
     const host_unified_buffer* get_host_accessible_alias() const noexcept final;
+    
+    void record_queue(device_queue &queue) = 0;
 
 }; 
 

--- a/include/xmipp4/core/compute/host/host_unified_buffer.hpp
+++ b/include/xmipp4/core/compute/host/host_unified_buffer.hpp
@@ -59,7 +59,7 @@ public:
     host_unified_buffer* get_host_accessible_alias() noexcept final;
     const host_unified_buffer* get_host_accessible_alias() const noexcept final;
     
-    void record_queue(device_queue &queue) = 0;
+    void record_queue(device_queue &queue) override = 0;
 
 }; 
 

--- a/include/xmipp4/core/compute/host/host_unified_buffer.hpp
+++ b/include/xmipp4/core/compute/host/host_unified_buffer.hpp
@@ -54,10 +54,10 @@ public:
     void* get_data() noexcept override = 0;
     const void* get_data() const noexcept override = 0;
 
-    device_buffer* get_device_accessible_alias() noexcept final;
-    const device_buffer* get_device_accessible_alias() const noexcept final;
-    host_buffer* get_host_accessible_alias() noexcept final;
-    const host_buffer* get_host_accessible_alias() const noexcept final;
+    host_unified_buffer* get_device_accessible_alias() noexcept final;
+    const host_unified_buffer* get_device_accessible_alias() const noexcept final;
+    host_unified_buffer* get_host_accessible_alias() noexcept final;
+    const host_unified_buffer* get_host_accessible_alias() const noexcept final;
 
 }; 
 

--- a/include/xmipp4/core/compute/host/host_unified_memory_allocator.hpp
+++ b/include/xmipp4/core/compute/host/host_unified_memory_allocator.hpp
@@ -59,6 +59,12 @@ public:
     host_unified_memory_allocator& 
     operator=(host_unified_memory_allocator &&other) = default;
 
+    std::unique_ptr<host_unified_buffer> 
+    create_unified_buffer(numerical_type type, std::size_t count );
+
+    std::shared_ptr<host_unified_buffer> 
+    create_unified_buffer_shared(numerical_type type, std::size_t count );
+
     std::unique_ptr<device_buffer> 
     create_device_buffer(numerical_type type, 
                          std::size_t count, 

--- a/include/xmipp4/core/compute/host/host_unified_memory_allocator.hpp
+++ b/include/xmipp4/core/compute/host/host_unified_memory_allocator.hpp
@@ -60,21 +60,29 @@ public:
     operator=(host_unified_memory_allocator &&other) = default;
 
     std::unique_ptr<device_buffer> 
-    create_buffer(numerical_type type, 
-                  std::size_t count, 
-                  device_queue &queue ) override;
-
-    std::shared_ptr<device_buffer> 
-    create_buffer_shared(numerical_type type, 
+    create_device_buffer(numerical_type type, 
                          std::size_t count, 
                          device_queue &queue ) override;
 
+    std::shared_ptr<device_buffer> 
+    create_device_buffer_shared(numerical_type type, 
+                                std::size_t count, 
+                                device_queue &queue ) override;
+
     std::unique_ptr<host_buffer> 
-    create_buffer(numerical_type type, std::size_t count ) override;
+    create_host_buffer(numerical_type type, 
+                       std::size_t count, 
+                       device_queue &queue ) override;
 
     std::shared_ptr<host_buffer> 
-    create_buffer_shared(numerical_type type, 
-                         std::size_t count ) override;
+    create_host_buffer_shared(numerical_type type, 
+                              std::size_t count, 
+                              device_queue &queue ) override;
+    std::unique_ptr<host_buffer> 
+    create_host_buffer(numerical_type type, std::size_t count ) override;
+
+    std::shared_ptr<host_buffer> 
+    create_host_buffer_shared(numerical_type type, std::size_t count ) override;
 
 }; 
 

--- a/include/xmipp4/core/compute/host_buffer.hpp
+++ b/include/xmipp4/core/compute/host_buffer.hpp
@@ -41,6 +41,7 @@ namespace compute
 {
 
 class device_buffer;
+class device_queue;
 
 /**
  * @brief Abstract class defining an in-host memory
@@ -109,6 +110,15 @@ public:
      */
     virtual 
     const device_buffer* get_device_accessible_alias() const noexcept = 0;
+
+    /**
+     * @brief Acknowledge that the buffer is being used in a queue other than
+     * the one used for allocation.
+     * 
+     * @param queue The queue where the buffer is being used.
+     * 
+     */
+    virtual void record_queue(device_queue &queue) = 0;
 
 };
 

--- a/include/xmipp4/core/compute/host_memory_allocator.hpp
+++ b/include/xmipp4/core/compute/host_memory_allocator.hpp
@@ -66,12 +66,55 @@ public:
      * 
      * @param type Numerical type of the buffer.
      * @param count Number of elements in the buffer.
+     * @param queue Queue where the allocation and deallocation takes place.
      * @return std::unique_ptr<host_buffer> The buffer.
      * 
+     * @note Using the buffer in an queue other than the one
+     * used for allocation-deallocation requires explicit
+     * synchronization.
+     * @note Memory allocated here is not available to the host
+     * until the queue has been executed until this point. Use
+     * device_to_host synchronization primitives to assure that
+     * the buffer is accessible.
      */
     virtual std::unique_ptr<host_buffer> 
-    create_buffer(numerical_type type, 
-                  std::size_t count ) = 0;
+    create_host_buffer(numerical_type type, 
+                       std::size_t count,
+                       device_queue& queue ) = 0;
+
+    /**
+     * @brief Allocate a buffer in this host.
+     * 
+     * @param type Numerical type of the buffer.
+     * @param count Number of elements in the buffer.
+     * @param queue Queue where the allocation and deallocation takes place.
+     * @return std::shared_ptr<host_buffer> The buffer.
+     * 
+     * @note Using the buffer in an queue other than the one
+     * used for allocation-deallocation requires explicit
+     * synchronization.
+     * @note Memory allocated here is not available to the host
+     * until the queue has been executed until this point. Use
+     * device_to_host synchronization primitives to assure that
+     * the buffer is accessible.
+     */
+    virtual std::shared_ptr<host_buffer> 
+    create_host_buffer_shared(numerical_type type, 
+                              std::size_t count,
+                              device_queue &queue ) = 0;
+
+    /**
+     * @brief Allocate a buffer in this host.
+     * 
+     * @param type Numerical type of the buffer.
+     * @param count Number of elements in the buffer.
+     * @return std::unique_ptr<host_buffer> The buffer.
+     * 
+     * @note Unlike the previous functions, the memory allocated here
+     * is inmediafly available to the host.
+     */
+    virtual std::unique_ptr<host_buffer> 
+    create_host_buffer(numerical_type type, std::size_t count) = 0;
 
     /**
      * @brief Allocate a buffer in this host.
@@ -80,10 +123,12 @@ public:
      * @param count Number of elements in the buffer.
      * @return std::shared_ptr<host_buffer> The buffer.
      * 
+     * @note Unlike the previous functions, the memory allocated here
+     * is inmediafly available to the host.
      */
     virtual std::shared_ptr<host_buffer> 
-    create_buffer_shared(numerical_type type, 
-                         std::size_t count ) = 0;
+    create_host_buffer_shared(numerical_type type, std::size_t count) = 0;
+
 
 }; 
 

--- a/include/xmipp4/core/compute/host_to_device_transfer.hpp
+++ b/include/xmipp4/core/compute/host_to_device_transfer.hpp
@@ -157,25 +157,6 @@ public:
              device_memory_allocator &allocator,
              device_queue &queue ) = 0;
 
-    /**
-     * @brief Block the current thread until the transfers have finished.
-     * 
-     */
-    virtual void wait() = 0;
-
-    /**
-     * @brief Block the provided queue until the transfer has finished 
-     * 
-     * @param queue The queue to be blocked.
-     * 
-     * @note The queue provided to the transfer is implicitly blocked.
-     * This function may not be used with the same queue used for the 
-     * transfer. Instead, this function is meant to be used with other
-     * queues that await the transferred data.
-     * 
-     */
-    virtual void wait(device_queue &queue) = 0;
-
 }; 
 
 } // namespace compute

--- a/include/xmipp4/core/compute/host_to_device_transfer.hpp
+++ b/include/xmipp4/core/compute/host_to_device_transfer.hpp
@@ -83,7 +83,7 @@ public:
      * 
      */
     virtual void
-    transfer_copy(const std::shared_ptr<const host_buffer> &src_buffer,
+    transfer_copy(const host_buffer &src_buffer,
                   device_buffer &dst_buffer, 
                   device_queue &queue ) = 0;
 
@@ -110,7 +110,7 @@ public:
      * 
      */
     virtual void
-    transfer_copy(const std::shared_ptr<const host_buffer> &src_buffer,
+    transfer_copy(const host_buffer &src_buffer,
                   device_buffer &dst_buffer,
                   span<const copy_region> regions,
                   device_queue &queue ) = 0;

--- a/src/compute/host/default_host_unified_buffer.cpp
+++ b/src/compute/host/default_host_unified_buffer.cpp
@@ -116,5 +116,10 @@ const void* default_host_unified_buffer::get_data() const noexcept
     return m_data;
 }
 
+void default_host_unified_buffer::record_queue(device_queue&)
+{
+    // No-op
+}
+
 } // namespace compute
 } // namespace xmipp4

--- a/src/compute/host/default_host_unified_buffer.hpp
+++ b/src/compute/host/default_host_unified_buffer.hpp
@@ -64,6 +64,8 @@ public:
     void* get_data() noexcept override;
     const void* get_data() const noexcept override;
 
+    void record_queue(device_queue &queue) override;
+
 private:
     numerical_type m_type;
     std::size_t m_count;

--- a/src/compute/host/host_transfer.cpp
+++ b/src/compute/host/host_transfer.cpp
@@ -39,37 +39,23 @@ namespace xmipp4
 namespace compute
 {
 
-static void require_nonnull(const host_buffer *buffer, const char *buffer_name)
-{
-    if (!buffer)
-    {
-        std::string message = buffer_name;
-        message += " cannot be null";
-        throw std::invalid_argument(message);
-    }
-}
-
-void host_transfer::transfer_copy(const std::shared_ptr<const host_buffer> &src_buffer, 
+void host_transfer::transfer_copy(const host_buffer &src_buffer, 
                                   device_buffer &dst_buffer, 
                                   device_queue& )
 {
-    require_nonnull(src_buffer.get(), "src_buffer");
-
     compute::copy(
-        *src_buffer, 
+        src_buffer, 
         dynamic_cast<host_unified_buffer&>(dst_buffer)
     );
 }
 
-void host_transfer::transfer_copy(const std::shared_ptr<const host_buffer> &src_buffer, 
+void host_transfer::transfer_copy(const host_buffer &src_buffer, 
                                   device_buffer &dst_buffer, 
                                   span<const copy_region> regions, 
                                   device_queue& )
 {
-    require_nonnull(src_buffer.get(), "src_buffer");
-
     compute::copy(
-        *src_buffer, 
+        src_buffer, 
         dynamic_cast<host_unified_buffer&>(dst_buffer), 
         regions
     );
@@ -94,27 +80,23 @@ host_transfer::transfer(const std::shared_ptr<const host_buffer> &buffer,
 }
 
 void host_transfer::transfer_copy(const device_buffer &src_buffer,
-                                  const std::shared_ptr<host_buffer> &dst_buffer,
+                                  host_buffer &dst_buffer,
                                   device_queue& )
 {
-    require_nonnull(dst_buffer.get(), "dst_buffer");
-
     compute::copy(
         dynamic_cast<const host_unified_buffer&>(src_buffer), 
-        *dst_buffer
+        dst_buffer
     );
 }
 
 void host_transfer::transfer_copy(const device_buffer &src_buffer,
-                                  const std::shared_ptr<host_buffer> &dst_buffer,
+                                  host_buffer &dst_buffer,
                                   span<const copy_region> regions, 
                                   device_queue& )
 {
-    require_nonnull(dst_buffer.get(), "dst_buffer");
-
     compute::copy(
         dynamic_cast<const host_unified_buffer&>(src_buffer), 
-        *dst_buffer,
+        dst_buffer,
         regions
     );
 }

--- a/src/compute/host/host_transfer.cpp
+++ b/src/compute/host/host_transfer.cpp
@@ -142,15 +142,5 @@ void host_transfer::copy(const device_buffer &src_buffer,
     );
 }
 
-void host_transfer::wait()
-{
-    // No-op, synchronous transfer.
-}
-
-void host_transfer::wait(device_queue&)
-{
-    // No-op, synchronous transfer.
-}
-
 } // namespace compute
 } // namespace xmipp4

--- a/src/compute/host/host_unified_buffer.cpp
+++ b/src/compute/host/host_unified_buffer.cpp
@@ -33,23 +33,23 @@ namespace xmipp4
 namespace compute
 {
 
-device_buffer* host_unified_buffer::get_device_accessible_alias() noexcept
+host_unified_buffer* host_unified_buffer::get_device_accessible_alias() noexcept
 {
     return this;
 }
 
-const device_buffer* 
+const host_unified_buffer* 
 host_unified_buffer::get_device_accessible_alias() const noexcept
 {
     return this;
 }
 
-host_buffer* host_unified_buffer::get_host_accessible_alias() noexcept
+host_unified_buffer* host_unified_buffer::get_host_accessible_alias() noexcept
 {
     return this;
 }
 
-const host_buffer* 
+const host_unified_buffer* 
 host_unified_buffer::get_host_accessible_alias() const noexcept
 {
     return this;

--- a/src/compute/host/host_unified_memory_allocator.cpp
+++ b/src/compute/host/host_unified_memory_allocator.cpp
@@ -37,31 +37,47 @@ namespace compute
 {
 
 std::unique_ptr<device_buffer> 
-host_unified_memory_allocator::create_buffer(numerical_type type,
-                                             std::size_t count,
-                                             device_queue& )
+host_unified_memory_allocator::create_device_buffer(numerical_type type,
+                                                    std::size_t count,
+                                                    device_queue& )
 {
     return std::make_unique<default_host_unified_buffer>(type, count);
 }
 
 std::shared_ptr<device_buffer> 
-host_unified_memory_allocator::create_buffer_shared(numerical_type type,
-                                                    std::size_t count,
-                                                    device_queue& )
+host_unified_memory_allocator::create_device_buffer_shared(numerical_type type,
+                                                           std::size_t count,
+                                                           device_queue& )
 {
     return std::make_shared<default_host_unified_buffer>(type, count);
 }
 
 std::unique_ptr<host_buffer> 
-host_unified_memory_allocator::create_buffer(numerical_type type, 
-                                             std::size_t count )
+host_unified_memory_allocator::create_host_buffer(numerical_type type,
+                                                  std::size_t count,
+                                                  device_queue& )
 {
     return std::make_unique<default_host_unified_buffer>(type, count);
 }
 
 std::shared_ptr<host_buffer> 
-host_unified_memory_allocator::create_buffer_shared(numerical_type type, 
-                                                    std::size_t count )
+host_unified_memory_allocator::create_host_buffer_shared(numerical_type type,
+                                                         std::size_t count,
+                                                         device_queue& )
+{
+    return std::make_shared<default_host_unified_buffer>(type, count);
+}
+
+std::unique_ptr<host_buffer> 
+host_unified_memory_allocator::create_host_buffer(numerical_type type, 
+                                                  std::size_t count )
+{
+    return std::make_unique<default_host_unified_buffer>(type, count);
+}
+
+std::shared_ptr<host_buffer> 
+host_unified_memory_allocator::create_host_buffer_shared(numerical_type type, 
+                                                         std::size_t count )
 {
     return std::make_shared<default_host_unified_buffer>(type, count);
 }

--- a/src/compute/host/host_unified_memory_allocator.cpp
+++ b/src/compute/host/host_unified_memory_allocator.cpp
@@ -36,12 +36,26 @@ namespace xmipp4
 namespace compute
 {
 
+std::unique_ptr<host_unified_buffer> 
+host_unified_memory_allocator::create_unified_buffer(numerical_type type, 
+                                                     std::size_t count )
+{
+    return std::make_unique<default_host_unified_buffer>(type, count);
+}
+
+std::shared_ptr<host_unified_buffer> 
+host_unified_memory_allocator::create_unified_buffer_shared(numerical_type type, 
+                                                            std::size_t count )
+{
+    return std::make_shared<default_host_unified_buffer>(type, count);
+}
+
 std::unique_ptr<device_buffer> 
 host_unified_memory_allocator::create_device_buffer(numerical_type type,
                                                     std::size_t count,
                                                     device_queue& )
 {
-    return std::make_unique<default_host_unified_buffer>(type, count);
+    return create_unified_buffer(type, count);
 }
 
 std::shared_ptr<device_buffer> 
@@ -49,7 +63,7 @@ host_unified_memory_allocator::create_device_buffer_shared(numerical_type type,
                                                            std::size_t count,
                                                            device_queue& )
 {
-    return std::make_shared<default_host_unified_buffer>(type, count);
+    return create_unified_buffer_shared(type, count);
 }
 
 std::unique_ptr<host_buffer> 
@@ -57,7 +71,7 @@ host_unified_memory_allocator::create_host_buffer(numerical_type type,
                                                   std::size_t count,
                                                   device_queue& )
 {
-    return std::make_unique<default_host_unified_buffer>(type, count);
+    return create_unified_buffer(type, count);
 }
 
 std::shared_ptr<host_buffer> 
@@ -65,21 +79,21 @@ host_unified_memory_allocator::create_host_buffer_shared(numerical_type type,
                                                          std::size_t count,
                                                          device_queue& )
 {
-    return std::make_shared<default_host_unified_buffer>(type, count);
+    return create_unified_buffer_shared(type, count);
 }
 
 std::unique_ptr<host_buffer> 
 host_unified_memory_allocator::create_host_buffer(numerical_type type, 
                                                   std::size_t count )
 {
-    return std::make_unique<default_host_unified_buffer>(type, count);
+    return create_unified_buffer(type, count);
 }
 
 std::shared_ptr<host_buffer> 
 host_unified_memory_allocator::create_host_buffer_shared(numerical_type type, 
                                                          std::size_t count )
 {
-    return std::make_shared<default_host_unified_buffer>(type, count);
+    return create_unified_buffer_shared(type, count);
 }
 
 } // namespace compute

--- a/tests/unitary/src/compute/test_host_buffer.cpp
+++ b/tests/unitary/src/compute/test_host_buffer.cpp
@@ -27,6 +27,7 @@
  */
 
 #include <xmipp4/core/compute/host_buffer.hpp>
+#include <xmipp4/core/compute/device_queue.hpp>
 
 #include <vector>
 
@@ -48,6 +49,7 @@ public:
     MAKE_CONST_MOCK0(get_data, const void* (), noexcept override);
     MAKE_MOCK0(get_device_accessible_alias, device_buffer* (), noexcept override);
     MAKE_CONST_MOCK0(get_device_accessible_alias, const device_buffer* (), noexcept override);
+    MAKE_MOCK1(record_queue, void (device_queue&), override);
 
 };
 


### PR DESCRIPTION
Switched minds and enabling asynchronous memory allocation in host memory, as most of the [similar implementations](https://github.com/rapidsai/rmm/blob/d4066fa611c803430c9bc5dbe8e243f89bb9a25c/include/rmm/mr/host/pinned_memory_resource.hpp#L63) also do it. Nevertheless, synchronous allocations are still allowed.

This simplifies host<->device transfers. As part of this simplification, this PR removes synchronization procedures (`wait`) from transfer interfaces, embracing single use interfaces. In addition, `*_copy` methods no longer require a `std::shared_ptr` for host buffers.