### PR TITLE
Added functions to obtain shared_ptr aliases of buffers

### DIFF
--- a/include/xmipp4/core/compute/device_buffer.hpp
+++ b/include/xmipp4/core/compute/device_buffer.hpp
@@ -30,6 +30,7 @@
 
 #include "../platform/dynamic_shared_object.h"
 
+#include <memory>
 #include <cstddef>
 
 namespace xmipp4 
@@ -95,7 +96,35 @@ public:
      */
     virtual void record_queue(device_queue &queue) = 0;
 
-}; 
+};
+
+
+
+/**
+ * @brief Get a host accessible alias of a device_buffer.
+ * 
+ * If this buffer is not host accessible, this method returns null.
+ * 
+ * @param buffer Buffer to be aliased. May be null, in which case null is
+ * returned.
+ * @return std::shared<host_buffer> Host accessible alias of the
+ * provided buffer.
+ */
+std::shared_ptr<host_buffer> 
+get_host_accessible_alias(const std::shared_ptr<device_buffer> &buffer) noexcept;
+
+/**
+ * @brief Get a host accessible alias of a device_buffer.
+ * 
+ * If this buffer is not host accessible, this method returns null.
+ * 
+ * @param buffer Buffer to be aliased. May be null, in which case null is
+ * returned.
+ * @return std::shared<const host_buffer> Host accessible alias of the
+ * provided buffer.
+ */
+std::shared_ptr<const host_buffer> 
+get_host_accessible_alias(const std::shared_ptr<const device_buffer> &buffer) noexcept;
 
 } // namespace compute
 } // namespace xmipp4

--- a/include/xmipp4/core/compute/host_buffer.hpp
+++ b/include/xmipp4/core/compute/host_buffer.hpp
@@ -32,6 +32,7 @@
 #include "../span.hpp"
 #include "../platform/dynamic_shared_object.h"
 
+#include <memory>
 #include <cstddef>
 
 namespace xmipp4 
@@ -111,6 +112,33 @@ public:
 
 };
 
+
+
+/**
+ * @brief Get a device accessible alias of a host_buffer.
+ * 
+ * If this buffer is not device accessible, this method returns null.
+ * 
+ * @param buffer Buffer to be aliased. May be null, in which case null is
+ * returned.
+ * @return std::shared<device_buffer> Device accessible alias of the
+ * provided buffer.
+ */
+std::shared_ptr<device_buffer> 
+get_device_accessible_alias(const std::shared_ptr<host_buffer> &buffer) noexcept;
+
+/**
+ * @brief Get a device accessible alias of a host_buffer.
+ * 
+ * If this buffer is not device accessible, this method returns null.
+ * 
+ * @param buffer Buffer to be aliased. May be null, in which case null is
+ * returned.
+ * @return std::shared<const device_buffer> Device accessible alias of the
+ * provided buffer.
+ */
+std::shared_ptr<const device_buffer> 
+get_device_accessible_alias(const std::shared_ptr<const host_buffer> &buffer) noexcept;
 
 /**
  * @brief Copy the contents of one buffer to another.

--- a/src/compute/device_buffer.cpp
+++ b/src/compute/device_buffer.cpp
@@ -1,0 +1,71 @@
+/***************************************************************************
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+ * 02111-1307  USA
+ *
+ *  All comments concerning this program package may be sent to the
+ *  e-mail address 'xmipp@cnb.csic.es'
+ ***************************************************************************/
+
+/**
+ * @file host_buffer.cpp
+ * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
+ * @brief Implementation of host_buffer.hpp
+ * @date 2024-12-08
+ * 
+ */
+
+#include <xmipp4/core/compute/device_buffer.hpp>
+
+namespace xmipp4
+{
+namespace compute
+{
+
+std::shared_ptr<host_buffer> 
+get_host_accessible_alias(const std::shared_ptr<device_buffer> &buffer) noexcept
+{
+    std::shared_ptr<host_buffer> result;
+
+    if (buffer)
+    {
+        auto *alias = buffer->get_host_accessible_alias();
+        if (alias)
+        {
+            result = std::shared_ptr<host_buffer>(buffer, alias);
+        }
+    }
+
+    return result;
+}
+
+std::shared_ptr<const host_buffer> 
+get_host_accessible_alias(const std::shared_ptr<const device_buffer> &buffer) noexcept
+{
+    std::shared_ptr<const host_buffer> result;
+
+    if (buffer)
+    {
+        const auto *alias = buffer->get_host_accessible_alias();
+        if (alias)
+        {
+            result = std::shared_ptr<const host_buffer>(buffer, alias);
+        }
+    }
+
+    return result;
+}
+
+} // namespace compute
+} // namespace xmipp4

--- a/src/compute/host/host_transfer.cpp
+++ b/src/compute/host/host_transfer.cpp
@@ -67,8 +67,7 @@ host_transfer::transfer(const std::shared_ptr<host_buffer> &buffer,
                         std::size_t,
                         device_queue&)
 {
-    // Returned buffer is an alias of the one received, not a copy
-    return std::dynamic_pointer_cast<device_buffer>(buffer);
+    return get_device_accessible_alias(buffer);
 }
 
 std::shared_ptr<const device_buffer> 
@@ -77,8 +76,7 @@ host_transfer::transfer(const std::shared_ptr<const host_buffer> &buffer,
                         std::size_t,
                         device_queue& )
 {
-    // Returned buffer is an alias of the one received, not a copy
-    return std::dynamic_pointer_cast<const device_buffer>(buffer);
+    return get_device_accessible_alias(buffer);
 }
 
 void host_transfer::transfer_copy(const device_buffer &src_buffer,
@@ -109,8 +107,7 @@ host_transfer::transfer(const std::shared_ptr<device_buffer> &buffer,
                         std::size_t,
                         device_queue& )
 {
-    // Returned buffer is an alias of the one received, not a copy
-    return std::dynamic_pointer_cast<host_buffer>(buffer); 
+    return get_host_accessible_alias(buffer);
 }
 
 std::shared_ptr<const host_buffer> 
@@ -119,8 +116,7 @@ host_transfer::transfer(const std::shared_ptr<const device_buffer> &buffer,
                         std::size_t,
                         device_queue& )
 {
-    // Returned buffer is an alias of the one received, not a copy
-    return std::dynamic_pointer_cast<const host_buffer>(buffer);
+    return get_host_accessible_alias(buffer);
 }
 
 

--- a/src/compute/host_buffer.cpp
+++ b/src/compute/host_buffer.cpp
@@ -39,6 +39,40 @@ namespace xmipp4
 namespace compute
 {
 
+std::shared_ptr<device_buffer> 
+get_device_accessible_alias(const std::shared_ptr<host_buffer> &buffer) noexcept
+{
+    std::shared_ptr<device_buffer> result;
+
+    if (buffer)
+    {
+        auto *alias = buffer->get_device_accessible_alias();
+        if (alias)
+        {
+            result = std::shared_ptr<device_buffer>(buffer, alias);
+        }
+    }
+
+    return result;
+}
+
+std::shared_ptr<const device_buffer> 
+get_device_accessible_alias(const std::shared_ptr<const host_buffer> &buffer) noexcept
+{
+    std::shared_ptr<const device_buffer> result;
+
+    if (buffer)
+    {
+        const auto *alias = buffer->get_device_accessible_alias();
+        if (alias)
+        {
+            result = std::shared_ptr<const device_buffer>(buffer, alias);
+        }
+    }
+
+    return result;
+}
+
 void copy(const host_buffer &src_buffer, host_buffer &dst_buffer)
 {
     const auto count = require_same_buffer_size(


### PR DESCRIPTION
Added possibility to obtain shared_ptr aliases from host/device buffers. In this manner, aliases can be managed, increasing memory management robustness. Adapting transfer functions in host to make use of this mechanism. 