### PR TITLE
Separating mocks in their own files

### DIFF
--- a/tests/unitary/src/communication/mock/mock_communicator_backend.hpp
+++ b/tests/unitary/src/communication/mock/mock_communicator_backend.hpp
@@ -1,0 +1,52 @@
+#pragma once
+
+/***************************************************************************
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+ * 02111-1307  USA
+ *
+ *  All comments concerning this program package may be sent to the
+ *  e-mail address 'xmipp@cnb.csic.es'
+ ***************************************************************************/
+
+/**
+ * @file mock_communicator_backend.cpp
+ * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
+ * @brief Mock for communicator_backend interface.
+ * @date 2024-12-10
+ */
+
+#include <xmipp4/core/communication/communicator_backend.hpp>
+
+#include <trompeloeil.hpp>
+
+namespace xmipp4
+{
+namespace communication
+{
+
+class mock_communicator_backend final
+    : public communicator_backend
+{
+public:
+    MAKE_MOCK0(get_name, std::string (), const noexcept override);
+    MAKE_MOCK0(get_version, version (), const noexcept override);
+    MAKE_MOCK0(is_available, bool (), const noexcept override);
+    MAKE_MOCK0(get_priority, backend_priority (), const noexcept override);
+    MAKE_MOCK0(get_world_communicator, std::shared_ptr<communicator> (), const override);
+
+};
+
+} // namespace communication
+} // namespace xmipp4

--- a/tests/unitary/src/communication/test_communicator_manager.cpp
+++ b/tests/unitary/src/communication/test_communicator_manager.cpp
@@ -27,30 +27,18 @@
 
 #include <xmipp4/core/communication/communicator_manager.hpp>
 
-#include <xmipp4/core/communication/communicator_backend.hpp>
 #include <xmipp4/core/exceptions/ambiguous_backend_error.hpp>
 #include <xmipp4/core/version.hpp>
 
 #include <algorithm>
 
+#include "mock/mock_communicator_backend.hpp"
+
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers.hpp>
-#include <trompeloeil.hpp>
 
 using namespace xmipp4;
 using namespace xmipp4::communication;
-
-class mock_communicator_backend final
-    : public communicator_backend
-{
-public:
-    MAKE_MOCK0(get_name, std::string (), const noexcept override);
-    MAKE_MOCK0(get_version, version (), const noexcept override);
-    MAKE_MOCK0(is_available, bool (), const noexcept override);
-    MAKE_MOCK0(get_priority, backend_priority (), const noexcept override);
-    MAKE_MOCK0(get_world_communicator, std::shared_ptr<communicator> (), const override);
-
-};
 
 TEST_CASE( "register communicator backend", "[communicator_manager]" ) 
 {

--- a/tests/unitary/src/compute/mock/mock_device_backend.hpp
+++ b/tests/unitary/src/compute/mock/mock_device_backend.hpp
@@ -1,0 +1,55 @@
+#pragma once
+
+/***************************************************************************
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+ * 02111-1307  USA
+ *
+ *  All comments concerning this program package may be sent to the
+ *  e-mail address 'xmipp@cnb.csic.es'
+ ***************************************************************************/
+
+/**
+ * @file mock_device_backend.cpp
+ * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
+ * @brief Mock for device_backend interface.
+ * @date 2024-12-10
+ */
+
+#include <xmipp4/core/compute/device_backend.hpp>
+
+#include <trompeloeil.hpp>
+
+namespace xmipp4
+{
+namespace compute
+{
+
+class mock_device_backend final
+    : public device_backend
+{
+public:
+    MAKE_MOCK0(get_name, std::string (), const noexcept override);
+    MAKE_MOCK0(get_version, version (), const noexcept override);
+    MAKE_MOCK0(is_available, bool (), const noexcept override);
+    MAKE_MOCK0(get_priority, backend_priority (), const noexcept override);
+    MAKE_MOCK1(enumerate_devices, void (std::vector<std::size_t>&), const override);
+    MAKE_MOCK2(get_device_properties, bool (std::size_t, device_properties&), const override);
+    MAKE_MOCK2(create_device, std::unique_ptr<device> (std::size_t, const device_create_parameters&), override);
+    MAKE_MOCK2(create_device_shared, std::shared_ptr<device> (std::size_t, const device_create_parameters&), override);
+
+};
+
+} // namespace compute
+} // namespace xmipp4

--- a/tests/unitary/src/compute/mock/mock_device_buffer.hpp
+++ b/tests/unitary/src/compute/mock/mock_device_buffer.hpp
@@ -1,0 +1,51 @@
+#pragma once
+
+/***************************************************************************
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+ * 02111-1307  USA
+ *
+ *  All comments concerning this program package may be sent to the
+ *  e-mail address 'xmipp@cnb.csic.es'
+ ***************************************************************************/
+
+/**
+ * @file mock_device_buffer.cpp
+ * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
+ * @brief Mock for device_buffer interface.
+ * @date 2024-12-10
+ */
+
+#include <xmipp4/core/compute/device_buffer.hpp>
+
+#include <trompeloeil.hpp>
+
+namespace xmipp4
+{
+namespace compute
+{
+
+class mock_device_buffer final
+    : public device_buffer
+{
+public:
+    MAKE_MOCK0(get_size, std::size_t (), const noexcept override);
+    MAKE_MOCK0(get_host_accessible_alias, host_buffer* (), noexcept override);
+    MAKE_CONST_MOCK0(get_host_accessible_alias, const host_buffer* (), noexcept override);
+    MAKE_MOCK1(record_queue, void (device_queue&), override);
+
+};
+    
+} // namespace compute
+} // namespace xmipp4

--- a/tests/unitary/src/compute/mock/mock_host_buffer.hpp
+++ b/tests/unitary/src/compute/mock/mock_host_buffer.hpp
@@ -1,0 +1,53 @@
+#pragma once
+
+/***************************************************************************
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+ * 02111-1307  USA
+ *
+ *  All comments concerning this program package may be sent to the
+ *  e-mail address 'xmipp@cnb.csic.es'
+ ***************************************************************************/
+
+/**
+ * @file mock_host_buffer.cpp
+ * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
+ * @brief Mock for host_buffer interface.
+ * @date 2024-12-10
+ */
+
+#include <xmipp4/core/compute/host_buffer.hpp>
+
+#include <trompeloeil.hpp>
+
+namespace xmipp4
+{
+namespace compute
+{
+
+class mock_host_buffer final
+    : public host_buffer
+{
+public:
+    MAKE_MOCK0(get_size, std::size_t (), const noexcept override);
+    MAKE_MOCK0(get_data, void* (), noexcept override);
+    MAKE_CONST_MOCK0(get_data, const void* (), noexcept override);
+    MAKE_MOCK0(get_device_accessible_alias, device_buffer* (), noexcept override);
+    MAKE_CONST_MOCK0(get_device_accessible_alias, const device_buffer* (), noexcept override);
+    MAKE_MOCK1(record_queue, void (device_queue&), override);
+
+};
+
+} // namespace compute
+} // namespace xmipp4

--- a/tests/unitary/src/compute/test_device_buffer.cpp
+++ b/tests/unitary/src/compute/test_device_buffer.cpp
@@ -26,28 +26,14 @@
  * 
  */
 
-#include <xmipp4/core/compute/device_buffer.hpp>
 #include <xmipp4/core/compute/device_queue.hpp>
 
-#include <catch2/catch_test_macros.hpp>
-#include <trompeloeil.hpp>
+#include "mock/mock_device_buffer.hpp"
 
+#include <catch2/catch_test_macros.hpp>
 
 using namespace xmipp4;
 using namespace xmipp4::compute;
-
-class mock_device_buffer final
-    : public device_buffer
-{
-public:
-    MAKE_MOCK0(get_size, std::size_t (), const noexcept override);
-    MAKE_MOCK0(get_host_accessible_alias, host_buffer* (), noexcept override);
-    MAKE_CONST_MOCK0(get_host_accessible_alias, const host_buffer* (), noexcept override);
-    MAKE_MOCK1(record_queue, void (device_queue&), override);
-
-};
-
-
 
 TEST_CASE( "get_host_accessible_alias should return null when null is provided", "[device_buffer]" )
 {

--- a/tests/unitary/src/compute/test_device_manager.cpp
+++ b/tests/unitary/src/compute/test_device_manager.cpp
@@ -28,33 +28,17 @@
 #include <xmipp4/core/compute/device_manager.hpp>
 
 #include <xmipp4/core/compute/device.hpp>
-#include <xmipp4/core/compute/device_backend.hpp>
 #include <xmipp4/core/compute/device_create_parameters.hpp>
 #include <xmipp4/core/version.hpp>
 
 #include <algorithm>
 
+#include "mock/mock_device_backend.hpp"
+
 #include <catch2/catch_test_macros.hpp>
-#include <trompeloeil.hpp>
 
 using namespace xmipp4;
 using namespace xmipp4::compute;
-
-class mock_device_backend final
-    : public device_backend
-{
-public:
-    MAKE_MOCK0(get_name, std::string (), const noexcept override);
-    MAKE_MOCK0(get_version, version (), const noexcept override);
-    MAKE_MOCK0(is_available, bool (), const noexcept override);
-    MAKE_MOCK0(get_priority, backend_priority (), const noexcept override);
-    MAKE_MOCK1(enumerate_devices, void (std::vector<std::size_t>&), const override);
-    MAKE_MOCK2(get_device_properties, bool (std::size_t, device_properties&), const override);
-    MAKE_MOCK2(create_device, std::unique_ptr<device> (std::size_t, const device_create_parameters&), override);
-    MAKE_MOCK2(create_device_shared, std::shared_ptr<device> (std::size_t, const device_create_parameters&), override);
-
-};
-
 
 TEST_CASE( "register device backend", "[device_manager]" ) 
 {

--- a/tests/unitary/src/compute/test_host_buffer.cpp
+++ b/tests/unitary/src/compute/test_host_buffer.cpp
@@ -31,28 +31,13 @@
 
 #include <vector>
 
+#include "mock/mock_host_buffer.hpp"
+
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers.hpp>
-#include <trompeloeil.hpp>
-
 
 using namespace xmipp4;
 using namespace xmipp4::compute;
-
-class mock_host_buffer final
-    : public host_buffer
-{
-public:
-    MAKE_MOCK0(get_size, std::size_t (), const noexcept override);
-    MAKE_MOCK0(get_data, void* (), noexcept override);
-    MAKE_CONST_MOCK0(get_data, const void* (), noexcept override);
-    MAKE_MOCK0(get_device_accessible_alias, device_buffer* (), noexcept override);
-    MAKE_CONST_MOCK0(get_device_accessible_alias, const device_buffer* (), noexcept override);
-    MAKE_MOCK1(record_queue, void (device_queue&), override);
-
-};
-
-
 
 TEST_CASE( "get_device_accessible_alias should return null when null is provided", "[host_buffer]" )
 {


### PR DESCRIPTION
This enhances re-usability when re-using a mock in various tests.