### PR TITLE
Only installing Findhalf when used

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,8 @@ option(XMIPP4_CORE_BUILD_HALF "Build and install half instead of using a pre-ins
 # Set the CMake module path
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules)
 
+set(XMIPP4_CORE_LIBRARY_TARGET "xmipp4-core")
+
 # Include CMake packages
 include(CTest)
 include(GNUInstallDirs)
@@ -64,6 +66,12 @@ if (XMIPP4_CORE_BUILD_HALF)
 	fetch_half(VERSION 2.2.0)
 else()
 	find_package(half 2 REQUIRED)
+	install(
+		FILES 
+			${PROJECT_SOURCE_DIR}/cmake/modules/Findhalf.cmake
+		DESTINATION 
+			${CMAKE_INSTALL_LIBDIR}/cmake/${XMIPP4_CORE_LIBRARY_TARGET}/modules
+	)
 endif()
 
 # Find all source and header files
@@ -86,22 +94,22 @@ file(
 )
 
 # Create the shared library
-add_library(${PROJECT_NAME} SHARED ${SOURCES})
+add_library(${XMIPP4_CORE_LIBRARY_TARGET} SHARED ${SOURCES})
 set_target_properties(
-	${PROJECT_NAME} 
+	${XMIPP4_CORE_LIBRARY_TARGET} 
 	PROPERTIES 
 		SOVERSION ${PROJECT_VERSION}
 		CXX_STANDARD 20
 		DEFINE_SYMBOL "XMIPP4_CORE_EXPORTING"
 )
 target_include_directories(
-	${PROJECT_NAME} 
+	${XMIPP4_CORE_LIBRARY_TARGET} 
 	PUBLIC 
 	  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
       $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 target_compile_definitions(
-	${PROJECT_NAME} 
+	${XMIPP4_CORE_LIBRARY_TARGET} 
 	PRIVATE
 		VERSION_MAJOR=${CMAKE_PROJECT_VERSION_MAJOR}
 		VERSION_MINOR=${CMAKE_PROJECT_VERSION_MINOR}
@@ -110,11 +118,14 @@ target_compile_definitions(
 
 # Link dependencies
 if(MSVC)
-	target_link_libraries(${PROJECT_NAME} PRIVATE ws2_32) # Winsock
+	target_link_libraries(
+		${XMIPP4_CORE_LIBRARY_TARGET} 
+		PRIVATE ws2_32 # Winsock
+	) 
 endif()
 
 target_link_libraries(
-	${PROJECT_NAME} 
+	${XMIPP4_CORE_LIBRARY_TARGET} 
 	PUBLIC
 		Threads::Threads
 		spdlog::spdlog_header_only
@@ -127,14 +138,14 @@ target_link_libraries(
 if(XMIPP4_CORE_LINT_CLANG_TIDY)
 	find_program(CLANG_TIDY_EXE clang-tidy REQUIRED)
 	set_target_properties(
-		${PROJECT_NAME} 
+		${XMIPP4_CORE_LIBRARY_TARGET} 
 		PROPERTIES 
 			CXX_CLANG_TIDY ${CLANG_TIDY_EXE}
 	)
 elseif(XMIPP4_CORE_PRECOMPILED_HEADERS)
 	# Precompiler headers do not work with clang-tidy
 	target_precompile_headers(
-		${PROJECT_NAME} 
+		${XMIPP4_CORE_LIBRARY_TARGET} 
 		PRIVATE
 			${HEADERS}
 	)
@@ -142,54 +153,58 @@ endif()
 
 # Enable all warnings during compilation
 if(MSVC)
-	target_compile_options(${PROJECT_NAME} PRIVATE /W4)
-	target_compile_options(${PROJECT_NAME} PRIVATE /wd4996) # getenv warning
+	target_compile_options(
+		${XMIPP4_CORE_LIBRARY_TARGET} 
+		PRIVATE 
+			/W4
+			/wd4996 # getenv warning
+	)
 else()
-	target_compile_options(${PROJECT_NAME} PRIVATE -Wall -Wextra -Wpedantic)
+	target_compile_options(
+		${XMIPP4_CORE_LIBRARY_TARGET} 
+		PRIVATE 
+			-Wall 
+			-Wextra 
+			-Wpedantic
+	)
 endif()
 
 # Disable min/max macros in windows
 if(MSVC)
-	target_compile_definitions(${PROJECT_NAME} PUBLIC -DNOMINMAX)
+	target_compile_definitions(${XMIPP4_CORE_LIBRARY_TARGET} PUBLIC -DNOMINMAX)
 endif()
 
 # Install library's binary files and headers
 install(
-	TARGETS ${PROJECT_NAME}
-	EXPORT ${PROJECT_NAME}-targets
+	TARGETS ${XMIPP4_CORE_LIBRARY_TARGET}
+	EXPORT ${XMIPP4_CORE_LIBRARY_TARGET}-targets
 	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/xmipp4/
 )
 install(
 	DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/ 
 	DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
-install(
-	FILES 
-		${PROJECT_SOURCE_DIR}/cmake/modules/Findhalf.cmake
-	DESTINATION 
-		${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}/modules
-)
 
 # Create and install CMake config files
 configure_package_config_file(
   	${PROJECT_SOURCE_DIR}/cmake/config/config.cmake.in
-  	${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake
-  	INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
+  	${CMAKE_CURRENT_BINARY_DIR}/${XMIPP4_CORE_LIBRARY_TARGET}-config.cmake
+  	INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${XMIPP4_CORE_LIBRARY_TARGET}
 )
 write_basic_package_version_file(
-	${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake
+	${CMAKE_CURRENT_BINARY_DIR}/${XMIPP4_CORE_LIBRARY_TARGET}-config-version.cmake
 	COMPATIBILITY SameMinorVersion
 )
 install(
-  	EXPORT ${PROJECT_NAME}-targets
-  	FILE ${PROJECT_NAME}-targets.cmake
-  	DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
+  	EXPORT ${XMIPP4_CORE_LIBRARY_TARGET}-targets
+  	FILE ${XMIPP4_CORE_LIBRARY_TARGET}-targets.cmake
+  	DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${XMIPP4_CORE_LIBRARY_TARGET}
 )
 install(
   	FILES 
-		${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake
-		${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake
-  	DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
+		${CMAKE_CURRENT_BINARY_DIR}/${XMIPP4_CORE_LIBRARY_TARGET}-config.cmake
+		${CMAKE_CURRENT_BINARY_DIR}/${XMIPP4_CORE_LIBRARY_TARGET}-config-version.cmake
+  	DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${XMIPP4_CORE_LIBRARY_TARGET}
 )
 
 # Only build tests if it is the main project

--- a/cmake/config/config.cmake.in
+++ b/cmake/config/config.cmake.in
@@ -22,6 +22,8 @@
 
 @PACKAGE_INIT@
 
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/modules)
+
 include(CMakeFindDependencyMacro)
 
 find_dependency(Threads)

--- a/cmake/config/config.cmake.in
+++ b/cmake/config/config.cmake.in
@@ -20,14 +20,12 @@
 #  e-mail address 'xmipp@cnb.csic.es'
 # ***************************************************************************
 
-list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/modules)
+@PACKAGE_INIT@
 
 include(CMakeFindDependencyMacro)
 
-find_dependency(Threads REQUIRED)
+find_dependency(Threads)
 find_dependency(spdlog)
 find_dependency(half)
 
 include(${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake)
-
-@PACKAGE_INIT@

--- a/cmake/modules/Findhalf.cmake
+++ b/cmake/modules/Findhalf.cmake
@@ -49,5 +49,6 @@ find_package_handle_standard_args(half
 )
 
 # Define the target
-add_library(half INTERFACE IMPORTED)
-target_include_directories(half INTERFACE ${half_INCLUDE_DIR})
+set(HALF_TARGET "half")
+add_library(${HALF_TARGET} INTERFACE IMPORTED)
+target_include_directories(${HALF_TARGET} INTERFACE ${half_INCLUDE_DIR})

--- a/cmake/modules/Findhalf.cmake
+++ b/cmake/modules/Findhalf.cmake
@@ -32,13 +32,15 @@ find_path(
 )
 
 # Parse version from header file
-file(
-    STRINGS "${half_INCLUDE_DIR}/half.hpp"
-    half_VERSION_LINE
-    REGEX "Version"
-)
-string(REGEX MATCH "Version ([0-9]*\.[0-9]*\.[0-9]*)" _ ${half_VERSION_LINE})
-set(half_VERSION ${CMAKE_MATCH_1})
+if(half_INCLUDE_DIR)
+    file(
+        STRINGS "${half_INCLUDE_DIR}/half.hpp"
+        half_VERSION_LINE
+        REGEX "Version"
+    )
+    string(REGEX MATCH "Version ([0-9]*\.[0-9]*\.[0-9]*)" _ ${half_VERSION_LINE})
+    set(half_VERSION ${CMAKE_MATCH_1})
+endif()
 
 # Define the package variables
 find_package_handle_standard_args(half 

--- a/cmake/modules/fetch_half.cmake
+++ b/cmake/modules/fetch_half.cmake
@@ -25,46 +25,46 @@ cmake_minimum_required(VERSION 3.12)
 include(FetchContent)
 
 function(fetch_half)
-    set(options)
-    set(oneValueArgs VERSION)
-    set(multiValueArgs)
-    cmake_parse_arguments(PARSE_ARGV 0 arg
-        "${options}" "${oneValueArgs}" "${multiValueArgs}"
-    )
+	set(options)
+	set(oneValueArgs VERSION)
+	set(multiValueArgs)
+	cmake_parse_arguments(PARSE_ARGV 0 arg
+		"${options}" "${oneValueArgs}" "${multiValueArgs}"
+	)
 
 	cmake_policy(SET CMP0135 NEW) # To avoid warnings
-    set(NO_OP_COMMAND "${CMAKE_COMMAND} -E true")
-    FetchContent_Declare(
-        half
-        URL https://kumisystems.dl.sourceforge.net/project/half/half/${arg_VERSION}/half-${arg_VERSION}.zip
-        CONFIGURE_COMMAND ${NO_OP_COMMAND}
-        BUILD_COMMAND ${NO_OP_COMMAND}
-        INSTALL_COMMAND ${NO_OP_COMMAND}
-    )
-    FetchContent_MakeAvailable(half)
+	set(NO_OP_COMMAND "${CMAKE_COMMAND} -E true")
+	FetchContent_Declare(
+		half
+		URL https://kumisystems.dl.sourceforge.net/project/half/half/${arg_VERSION}/half-${arg_VERSION}.zip
+		CONFIGURE_COMMAND ${NO_OP_COMMAND}
+		BUILD_COMMAND ${NO_OP_COMMAND}
+		INSTALL_COMMAND ${NO_OP_COMMAND}
+	)
+	FetchContent_MakeAvailable(half)
 
 	set(half_INCLUDE_DIR ${half_SOURCE_DIR}/include)
 
 	# Define the target
 	add_library(half INTERFACE)
 	target_include_directories(
-        half 
-        INTERFACE
-            $<BUILD_INTERFACE:${half_INCLUDE_DIR}>
-            $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-    )
+		half 
+		INTERFACE
+			$<BUILD_INTERFACE:${half_INCLUDE_DIR}>
+			$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+	)
 
-    # Define install command
-    install(FILES ${half_INCLUDE_DIR}/half.hpp DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
-    install(
-        TARGETS half
-        EXPORT half-targets
-        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/half
-    )
-    install(
-        EXPORT half-targets
-        FILE half-config.cmake
-        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/half
-    )
+	# Define install command
+	install(FILES ${half_INCLUDE_DIR}/half.hpp DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+	install(
+		TARGETS half
+		EXPORT half-targets
+		LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/half
+	)
+	install(
+		EXPORT half-targets
+		FILE half-config.cmake
+		DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/half
+	)
 
 endfunction()

--- a/cmake/modules/fetch_half.cmake
+++ b/cmake/modules/fetch_half.cmake
@@ -46,25 +46,29 @@ function(fetch_half)
 	set(half_INCLUDE_DIR ${half_SOURCE_DIR}/include)
 
 	# Define the target
-	add_library(half INTERFACE)
+	set(HALF_TARGET "half")
+	add_library(${HALF_TARGET} INTERFACE)
 	target_include_directories(
-		half 
+		${HALF_TARGET}
 		INTERFACE
 			$<BUILD_INTERFACE:${half_INCLUDE_DIR}>
 			$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 	)
 
 	# Define install command
-	install(FILES ${half_INCLUDE_DIR}/half.hpp DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 	install(
-		TARGETS half
-		EXPORT half-targets
-		LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/half
+		FILES ${half_INCLUDE_DIR}/half.hpp 
+		DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 	)
 	install(
-		EXPORT half-targets
-		FILE half-config.cmake
-		DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/half
+		TARGETS ${HALF_TARGET}
+		EXPORT ${HALF_TARGET}-targets
+		LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/${HALF_TARGET}
+	)
+	install(
+		EXPORT ${HALF_TARGET}-targets
+		FILE ${HALF_TARGET}-config.cmake
+		DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${HALF_TARGET}
 	)
 
 endfunction()

--- a/cmake/modules/fetch_half.cmake
+++ b/cmake/modules/fetch_half.cmake
@@ -44,9 +44,27 @@ function(fetch_half)
     FetchContent_MakeAvailable(half)
 
 	set(half_INCLUDE_DIR ${half_SOURCE_DIR}/include)
-    install(FILES ${half_INCLUDE_DIR}/half.hpp DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 	# Define the target
-	add_library(half INTERFACE IMPORTED)
-	target_include_directories(half INTERFACE ${half_INCLUDE_DIR})
+	add_library(half INTERFACE)
+	target_include_directories(
+        half 
+        INTERFACE
+            $<BUILD_INTERFACE:${half_INCLUDE_DIR}>
+            $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+    )
+
+    # Define install command
+    install(FILES ${half_INCLUDE_DIR}/half.hpp DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+    install(
+        TARGETS half
+        EXPORT half-targets
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/half
+    )
+    install(
+        EXPORT half-targets
+        FILE half-config.cmake
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/half
+    )
+
 endfunction()


### PR DESCRIPTION
Fixes #128. Several style changes. The only relevant change is that the `Findhalf.cmake` script is only installed when used.