### PR TITLE
Removed unique_ptr method variants from compute and communication

### DIFF
--- a/include/xmipp4/core/communication/communicator.hpp
+++ b/include/xmipp4/core/communication/communicator.hpp
@@ -302,20 +302,6 @@ public:
      */
     virtual int get_rank() const = 0;
 
-     /**
-     * @brief Split the current communicator.
-     * 
-     * Split a communicator into multiple communicators containing.
-     * 
-     * @param colour The group where the current rank will be assigned to.
-     * @param rank_priority Hint to assign the rank in the new communicator.
-     * @return std::unique_ptr<communicator> The communicator where
-     * the current rank has been assigned to.
-     * 
-     */
-    virtual std::unique_ptr<communicator> split(int colour, 
-                                                int rank_priority ) const = 0;
-
     /**
      * @brief Split the current communicator.
      * 
@@ -327,8 +313,8 @@ public:
      * the current rank has been assigned to.
      * 
      */
-    virtual std::shared_ptr<communicator> split_shared(int colour, 
-                                                       int rank_priority ) const = 0;
+    virtual std::shared_ptr<communicator> split(int colour, 
+                                                int rank_priority ) const = 0;
 
     /**
      * @brief Synchronize all peers.

--- a/include/xmipp4/core/communication/communicator_backend.hpp
+++ b/include/xmipp4/core/communication/communicator_backend.hpp
@@ -62,7 +62,7 @@ public:
      * @return std::shared_ptr<communicator> Reference to the world
      * communicator.
      */
-    virtual std::shared_ptr<communicator> get_world_communicator() const = 0;
+    virtual std::shared_ptr<communicator> create_world_communicator() const = 0;
 
 }; 
 

--- a/include/xmipp4/core/communication/communicator_manager.hpp
+++ b/include/xmipp4/core/communication/communicator_manager.hpp
@@ -117,7 +117,7 @@ public:
      */
     XMIPP4_CORE_API
     std::shared_ptr<communicator> 
-    get_world_communicator(const std::string &name) const;
+    create_world_communicator(const std::string &name) const;
 
     /**
      * @brief Get the world communicator from the preferred backend.
@@ -127,7 +127,7 @@ public:
      * @see get_preferred_backend
      */
     XMIPP4_CORE_API
-    std::shared_ptr<communicator> get_preferred_world_communicator() const;
+    std::shared_ptr<communicator> create_preferred_world_communicator() const;
 
 private:
     class implementation;

--- a/include/xmipp4/core/communication/dummy/dummy_communicator.hpp
+++ b/include/xmipp4/core/communication/dummy/dummy_communicator.hpp
@@ -126,11 +126,8 @@ public:
 
     int get_rank() const override;
 
-    std::unique_ptr<communicator> split(int colour, 
+    std::shared_ptr<communicator> split(int colour, 
                                         int rank_priority ) const override;
-
-    std::shared_ptr<communicator> split_shared(int colour, 
-                                               int rank_priority ) const override;
 
     void barrier() override;
 

--- a/include/xmipp4/core/communication/dummy/dummy_communicator_backend.hpp
+++ b/include/xmipp4/core/communication/dummy/dummy_communicator_backend.hpp
@@ -47,7 +47,7 @@ public:
     version get_version() const noexcept override;
     bool is_available() const noexcept override;
     backend_priority get_priority() const noexcept override;
-    std::shared_ptr<communicator> get_world_communicator() const override;
+    std::shared_ptr<communicator> create_world_communicator() const override;
 
     static bool register_at(communicator_manager &manager);
 

--- a/include/xmipp4/core/compute/device.hpp
+++ b/include/xmipp4/core/compute/device.hpp
@@ -76,26 +76,10 @@ public:
     /**
      * @brief Create a memory allocator for this device.
      * 
-     * @return std::unique_ptr<device_memory_allocator> 
-     */
-    virtual std::unique_ptr<device_memory_allocator> 
-    create_device_memory_allocator() = 0;
-
-    /**
-     * @brief Create a memory allocator for this device.
-     * 
      * @return std::shared_ptr<device_memory_allocator> 
      */
     virtual std::shared_ptr<device_memory_allocator> 
-    create_device_memory_allocator_shared() = 0;
-
-    /**
-     * @brief Create a memory allocator for the host.
-     * 
-     * @return std::unique_ptr<host_memory_allocator> 
-     */
-    virtual std::unique_ptr<host_memory_allocator> 
-    create_host_memory_allocator() = 0;
+    create_device_memory_allocator() = 0;
 
     /**
      * @brief Create a memory allocator for the host.
@@ -103,15 +87,7 @@ public:
      * @return std::shared_ptr<host_memory_allocator> 
      */
     virtual std::shared_ptr<host_memory_allocator> 
-    create_host_memory_allocator_shared() = 0;
-
-    /**
-     * @brief Create a host to device transfer engine.
-     * 
-     * @return std::unique_ptr<host_to_device_transfer> 
-     */
-    virtual std::unique_ptr<host_to_device_transfer> 
-    create_host_to_device_transfer() = 0;
+    create_host_memory_allocator() = 0;
 
     /**
      * @brief Create a host to device transfer engine.
@@ -119,15 +95,7 @@ public:
      * @return std::shared_ptr<host_to_device_transfer> 
      */
     virtual std::shared_ptr<host_to_device_transfer> 
-    create_host_to_device_transfer_shared() = 0;
-
-    /**
-     * @brief Create a device to host transfer engine.
-     * 
-     * @return std::unique_ptr<device_to_host_transfer> 
-     */
-    virtual std::unique_ptr<device_to_host_transfer> 
-    create_device_to_host_transfer() = 0;
+    create_host_to_device_transfer() = 0;
 
     /**
      * @brief Create a device to host transfer engine.
@@ -135,15 +103,7 @@ public:
      * @return std::shared_ptr<device_to_host_transfer> 
      */
     virtual std::shared_ptr<device_to_host_transfer> 
-    create_device_to_host_transfer_shared() = 0;
-
-    /**
-     * @brief Create a device buffer copy engine.
-     * 
-     * @return std::unique_ptr<device_copy> 
-     */
-    virtual std::unique_ptr<device_copy> 
-    create_device_copy() = 0;
+    create_device_to_host_transfer() = 0;
 
     /**
      * @brief Create a device buffer copy engine.
@@ -151,15 +111,7 @@ public:
      * @return std::shared_ptr<device_copy> 
      */
     virtual std::shared_ptr<device_copy> 
-    create_device_copy_shared() = 0;
-
-    /**
-     * @brief Create an intra-device synchronization primitive.
-     * 
-     * @return std::unique_ptr<device_event> 
-     */
-    virtual std::unique_ptr<device_event>
-    create_device_event() = 0;
+    create_device_copy() = 0;
 
     /**
      * @brief Create an intra-device synchronization primitive.
@@ -167,15 +119,7 @@ public:
      * @return std::shared_ptr<device_event> 
      */
     virtual std::shared_ptr<device_event>
-    create_device_event_shared() = 0;
-
-    /**
-     * @brief Create a device to host synchronization primitive.
-     * 
-     * @return std::unique_ptr<device_to_host_event> 
-     */
-    virtual std::unique_ptr<device_to_host_event>
-    create_device_to_host_event() = 0;
+    create_device_event() = 0;
 
     /**
      * @brief Create a device to host synchronization primitive.
@@ -183,7 +127,7 @@ public:
      * @return std::shared_ptr<device_to_host_event> 
      */
     virtual std::shared_ptr<device_to_host_event>
-    create_device_to_host_event_shared() = 0;
+    create_device_to_host_event() = 0;
 
 }; 
 

--- a/include/xmipp4/core/compute/device_backend.hpp
+++ b/include/xmipp4/core/compute/device_backend.hpp
@@ -87,20 +87,10 @@ public:
      * 
      * @param id The identifier of the device.
      * @param params Parameters used for device instantiation.
-     * @return std::unique_ptr<device> The device handle.
-     */
-    virtual std::unique_ptr<device> 
-    create_device(std::size_t id, const device_create_parameters &params) = 0;
-
-    /**
-     * @brief Create a device handle for the given device identifier.
-     * 
-     * @param id The identifier of the device.
-     * @param params Parameters used for device instantiation.
      * @return std::shared_ptr<device> The device handle.
      */
     virtual std::shared_ptr<device> 
-    create_device_shared(std::size_t id, const device_create_parameters &params) = 0;
+    create_device(std::size_t id, const device_create_parameters &params) = 0;
 
 }; 
 

--- a/include/xmipp4/core/compute/device_manager.hpp
+++ b/include/xmipp4/core/compute/device_manager.hpp
@@ -121,22 +121,11 @@ public:
      * 
      * @param index Index of the device.
      * @param params Parameters used for device instantiation.
-     * @return std::unique_ptr<device> The device handle.
-     */
-    XMIPP4_CORE_API std::unique_ptr<device> 
-    create_device(const device_index &index, 
-                  const device_create_parameters &params ) const;
-
-    /**
-     * @brief Create a device handle.
-     * 
-     * @param index Index of the device.
-     * @param params Parameters used for device instantiation.
      * @return std::shared_ptr<device> The device handle.
      */
     XMIPP4_CORE_API std::shared_ptr<device> 
-    create_device_shared(const device_index &index,
-                         const device_create_parameters &params ) const;
+    create_device(const device_index &index,
+                  const device_create_parameters &params ) const;
 
 private:
     class implementation;

--- a/include/xmipp4/core/compute/device_memory_allocator.hpp
+++ b/include/xmipp4/core/compute/device_memory_allocator.hpp
@@ -66,23 +66,6 @@ public:
      * @param size Number of bytes in the buffer.
      * @param alignment Alignment requirements for the data in the buffer.
      * @param queue Queue where the allocation and deallocation takes place.
-     * @return std::unique_ptr<device_buffer> The buffer.
-     * 
-     * @note Using the buffer in an queue other than the one
-     * used for allocation-deallocation requires explicit
-     * synchronization.
-     */
-    virtual std::unique_ptr<device_buffer> 
-    create_device_buffer(std::size_t size,
-                         std::size_t alignment,
-                         device_queue &queue ) = 0;
-
-    /**
-     * @brief Allocate a buffer in this device.
-     * 
-     * @param size Number of bytes in the buffer.
-     * @param alignment Alignment requirements for the data in the buffer.
-     * @param queue Queue where the allocation and deallocation takes place.
      * @return std::shared_ptr<device_buffer> The buffer.
 
      * @note Using the buffer in an queue other than the one
@@ -90,9 +73,9 @@ public:
      * synchronization.
      */
     virtual std::shared_ptr<device_buffer> 
-    create_device_buffer_shared(std::size_t size, 
-                                std::size_t alignment,
-                                device_queue &queue ) = 0;
+    create_device_buffer(std::size_t size, 
+                         std::size_t alignment,
+                         device_queue &queue ) = 0;
 
 }; 
 

--- a/include/xmipp4/core/compute/host/host_device.hpp
+++ b/include/xmipp4/core/compute/host/host_device.hpp
@@ -37,6 +37,10 @@ namespace xmipp4
 namespace compute
 {
 
+class host_unified_memory_allocator;
+class host_transfer;
+class host_event;
+
 /**
  * @brief Special implementation of the device interface to be able to use
  * the "host" as a device.
@@ -46,43 +50,36 @@ class host_device final
     : public device
 {
 public:
+    host_device();
+    ~host_device() override = default;
+
     host_device_queue_pool& get_queue_pool() override;
 
-    std::unique_ptr<device_memory_allocator> 
-    create_device_memory_allocator() override;
     std::shared_ptr<device_memory_allocator> 
-    create_device_memory_allocator_shared() override;
+    create_device_memory_allocator() override;
 
-    std::unique_ptr<host_memory_allocator> 
-    create_host_memory_allocator() override;
     std::shared_ptr<host_memory_allocator> 
-    create_host_memory_allocator_shared() override;
+    create_host_memory_allocator() override;
 
-    std::unique_ptr<host_to_device_transfer> 
-    create_host_to_device_transfer() override;
     std::shared_ptr<host_to_device_transfer> 
-    create_host_to_device_transfer_shared() override;
+    create_host_to_device_transfer() override;
 
-    std::unique_ptr<device_to_host_transfer> 
-    create_device_to_host_transfer() override;
     std::shared_ptr<device_to_host_transfer> 
-    create_device_to_host_transfer_shared() override;
+    create_device_to_host_transfer() override;
 
-    std::unique_ptr<device_copy> 
-    create_device_copy() override;
     std::shared_ptr<device_copy> 
-    create_device_copy_shared() override;
+    create_device_copy() override;
 
-    std::unique_ptr<device_event> create_device_event() override;
-    std::shared_ptr<device_event> create_device_event_shared() override;
+    std::shared_ptr<device_event> create_device_event() override;
 
-    std::unique_ptr<device_to_host_event> 
-    create_device_to_host_event() override;
     std::shared_ptr<device_to_host_event> 
-    create_device_to_host_event_shared() override;
+    create_device_to_host_event() override;
 
 private:
     host_device_queue_pool m_queue_pool;
+    std::shared_ptr<host_unified_memory_allocator> m_allocator;
+    std::shared_ptr<host_transfer> m_transfer;
+    std::shared_ptr<host_event> m_event;
 
 }; 
 

--- a/include/xmipp4/core/compute/host/host_device_backend.hpp
+++ b/include/xmipp4/core/compute/host/host_device_backend.hpp
@@ -55,12 +55,10 @@ public:
     bool get_device_properties(std::size_t id, 
                                device_properties &desc) const override;
 
-    std::unique_ptr<device> 
-    create_device(std::size_t id, 
-                  const device_create_parameters &params ) override;
+
     std::shared_ptr<device>
-    create_device_shared(std::size_t id,
-                         const device_create_parameters &params ) override;
+    create_device(std::size_t id,
+                  const device_create_parameters &params ) override;
 
     static bool register_at(device_manager &manager);
 

--- a/include/xmipp4/core/compute/host/host_unified_memory_allocator.hpp
+++ b/include/xmipp4/core/compute/host/host_unified_memory_allocator.hpp
@@ -59,36 +59,21 @@ public:
     host_unified_memory_allocator& 
     operator=(host_unified_memory_allocator &&other) = default;
 
-    std::unique_ptr<host_unified_buffer> 
+    std::shared_ptr<host_unified_buffer> 
     create_unified_buffer(std::size_t size, std::size_t alignment);
 
-    std::shared_ptr<host_unified_buffer> 
-    create_unified_buffer_shared(std::size_t size, std::size_t alignment);
-
-    std::unique_ptr<device_buffer> 
+    std::shared_ptr<device_buffer> 
     create_device_buffer(std::size_t size, 
-                         std::size_t alignment, 
+                         std::size_t alignment,
                          device_queue &queue ) override;
 
-    std::shared_ptr<device_buffer> 
-    create_device_buffer_shared(std::size_t size, 
-                                std::size_t alignment,
-                                device_queue &queue ) override;
-
-    std::unique_ptr<host_buffer> 
+    std::shared_ptr<host_buffer> 
     create_host_buffer(std::size_t size, 
                        std::size_t alignment,
                        device_queue &queue ) override;
 
     std::shared_ptr<host_buffer> 
-    create_host_buffer_shared(std::size_t size, 
-                              std::size_t alignment,
-                              device_queue &queue ) override;
-    std::unique_ptr<host_buffer> 
     create_host_buffer(std::size_t size, std::size_t alignment) override;
-
-    std::shared_ptr<host_buffer> 
-    create_host_buffer_shared(std::size_t size, std::size_t alignment) override;
 
 }; 
 

--- a/include/xmipp4/core/compute/host_memory_allocator.hpp
+++ b/include/xmipp4/core/compute/host_memory_allocator.hpp
@@ -66,7 +66,7 @@ public:
      * @param size Number of bytes in the buffer.
      * @param alignment Alignment requirements for the data in the buffer.
      * @param queue Queue where the allocation and deallocation takes place.
-     * @return std::unique_ptr<host_buffer> The buffer.
+     * @return std::shared_ptr<host_buffer> The buffer.
      * 
      * @note Using the buffer in an queue other than the one
      * used for allocation-deallocation requires explicit
@@ -76,38 +76,17 @@ public:
      * device_to_host synchronization primitives to assure that
      * the buffer is accessible.
      */
-    virtual std::unique_ptr<host_buffer> 
-    create_host_buffer(std::size_t size,
+    virtual std::shared_ptr<host_buffer> 
+    create_host_buffer(std::size_t size, 
                        std::size_t alignment,
-                       device_queue& queue ) = 0;
+                       device_queue &queue ) = 0;
 
     /**
      * @brief Allocate a buffer in this host.
      * 
      * @param size Number of bytes in the buffer.
      * @param alignment Alignment requirements for the data in the buffer.
-     * @param queue Queue where the allocation and deallocation takes place.
      * @return std::shared_ptr<host_buffer> The buffer.
-     * 
-     * @note Using the buffer in an queue other than the one
-     * used for allocation-deallocation requires explicit
-     * synchronization.
-     * @note Memory allocated here is not available to the host
-     * until the queue has been executed until this point. Use
-     * device_to_host synchronization primitives to assure that
-     * the buffer is accessible.
-     */
-    virtual std::shared_ptr<host_buffer> 
-    create_host_buffer_shared(std::size_t size, 
-                              std::size_t alignment,
-                              device_queue &queue ) = 0;
-
-    /**
-     * @brief Allocate a buffer in this host.
-     * 
-     * @param size Number of bytes in the buffer.
-     * @param alignment Alignment requirements for the data in the buffer.
-     * @return std::unique_ptr<host_buffer> The buffer.
      * 
      * @note Unlike the previous functions, the memory allocated here
      * is immediately available to the host. Likewise, the memory is
@@ -115,24 +94,8 @@ public:
      * remember recording the queue onto the buffer to prevent premature
      * deallocation.
      */
-    virtual std::unique_ptr<host_buffer> 
+    virtual std::shared_ptr<host_buffer> 
     create_host_buffer(std::size_t size, std::size_t alignment) = 0;
-
-    /**
-     * @brief Allocate a buffer in this host.
-     * 
-     * @param size Number of bytes in the buffer.
-     * @param alignment Alignment requirements for the data in the buffer.
-     * @return std::shared_ptr<host_buffer> The buffer.
-     * 
-     * @note Unlike the previous functions, the memory allocated here
-     * is immediately available to the host. Likewise, the memory is
-     * immediately deallocated upon buffer destruction. If used on a queue
-     * remember recording the queue onto the buffer to prevent premature
-     * deallocation.
-     */
-    virtual std::shared_ptr<host_buffer> 
-    create_host_buffer_shared(std::size_t size, std::size_t alignment) = 0;
 
 }; 
 

--- a/src/communication/communicator_manager.cpp
+++ b/src/communication/communicator_manager.cpp
@@ -151,13 +151,13 @@ private:
 
 static 
 std::shared_ptr<communicator> 
-obtain_communicator(const communicator_backend* backend)
+create_communicator(const communicator_backend* backend)
 {
     std::shared_ptr<communicator> result;
     
     if (backend)
     {
-        result = backend->get_world_communicator();
+        result = backend->create_world_communicator();
     }
 
     return result;
@@ -199,15 +199,15 @@ communicator_manager::get_preferred_backend() const
 }
 
 std::shared_ptr<communicator>
-communicator_manager::get_world_communicator(const std::string &name) const
+communicator_manager::create_world_communicator(const std::string &name) const
 {
-    return obtain_communicator(get_backend(name));
+    return create_communicator(get_backend(name));
 }
 
 std::shared_ptr<communicator>
-communicator_manager::get_preferred_world_communicator() const
+communicator_manager::create_preferred_world_communicator() const
 {
-    return obtain_communicator(get_preferred_backend());
+    return create_communicator(get_preferred_backend());
 }
 
 } // namespace communication

--- a/src/communication/dummy/dummy_communicator.cpp
+++ b/src/communication/dummy/dummy_communicator.cpp
@@ -182,14 +182,8 @@ int dummy_communicator::get_rank() const
     return 0;
 }
 
-std::unique_ptr<communicator> 
-dummy_communicator::split(int, int) const
-{
-    return std::make_unique<dummy_communicator>();
-}
-
 std::shared_ptr<communicator> 
-dummy_communicator::split_shared(int, int) const
+dummy_communicator::split(int, int) const
 {
     return std::make_shared<dummy_communicator>();
 }

--- a/src/communication/dummy/dummy_communicator_backend.cpp
+++ b/src/communication/dummy/dummy_communicator_backend.cpp
@@ -59,7 +59,7 @@ backend_priority dummy_communicator_backend::get_priority() const noexcept
 }
 
 std::shared_ptr<communicator> 
-dummy_communicator_backend::get_world_communicator() const
+dummy_communicator_backend::create_world_communicator() const
 {
     return std::make_shared<dummy_communicator>();
 }

--- a/src/compute/device_manager.cpp
+++ b/src/compute/device_manager.cpp
@@ -146,31 +146,16 @@ bool device_manager::get_device_properties(const device_index &index,
     return result;
 }
 
-std::unique_ptr<device>
+std::shared_ptr<device> 
 device_manager::create_device(const device_index& index,
                               const device_create_parameters &params ) const
-{
-    std::unique_ptr<device> result;
-
-    auto *backend = get_backend(index.get_backend_name());
-    if (backend)
-    {
-        result = backend->create_device(index.get_device_id(), params);
-    }
-
-    return result;
-}
-
-std::shared_ptr<device> 
-device_manager::create_device_shared(const device_index& index,
-                                     const device_create_parameters &params ) const
 {
     std::shared_ptr<device> result;
 
     auto *backend = get_backend(index.get_backend_name());
     if (backend)
     {
-        result = backend->create_device_shared(index.get_device_id(), params);
+        result = backend->create_device(index.get_device_id(), params);
     }
 
     return result;

--- a/src/compute/host/host_device.cpp
+++ b/src/compute/host/host_device.cpp
@@ -38,90 +38,58 @@ namespace xmipp4
 namespace compute
 {
 
+host_device::host_device()
+    : m_queue_pool()
+    , m_allocator(std::make_shared<host_unified_memory_allocator>())
+    , m_transfer(std::make_shared<host_transfer>())
+    , m_event(std::make_shared<host_event>())
+{
+}
+
 host_device_queue_pool& host_device::get_queue_pool()
 {
     return m_queue_pool;
 }
 
-std::unique_ptr<device_memory_allocator> 
-host_device::create_device_memory_allocator()
-{
-    return std::make_unique<host_unified_memory_allocator>();
-}
-
 std::shared_ptr<device_memory_allocator> 
-host_device::create_device_memory_allocator_shared() 
+host_device::create_device_memory_allocator() 
 {
-    return std::make_shared<host_unified_memory_allocator>();
-}
-std::unique_ptr<host_memory_allocator> 
-host_device::create_host_memory_allocator()
-{
-    return std::make_unique<host_unified_memory_allocator>();
+    return m_allocator;
 }
 
 std::shared_ptr<host_memory_allocator> 
-host_device::create_host_memory_allocator_shared() 
+host_device::create_host_memory_allocator() 
 {
-    return std::make_shared<host_unified_memory_allocator>();
-}
-
-std::unique_ptr<host_to_device_transfer> 
-host_device::create_host_to_device_transfer()
-{
-    return std::make_unique<host_transfer>();
+    return m_allocator;
 }
 
 std::shared_ptr<host_to_device_transfer> 
-host_device::create_host_to_device_transfer_shared()
+host_device::create_host_to_device_transfer()
 {
-    return std::make_shared<host_transfer>();
-}
-
-std::unique_ptr<device_to_host_transfer> 
-host_device::create_device_to_host_transfer()
-{
-    return std::make_unique<host_transfer>();
+    return m_transfer;
 }
 
 std::shared_ptr<device_to_host_transfer> 
-host_device::create_device_to_host_transfer_shared()
+host_device::create_device_to_host_transfer()
 {
-    return std::make_shared<host_transfer>();
-}
-
-std::unique_ptr<device_copy> 
-host_device::create_device_copy()
-{
-    return std::make_unique<host_transfer>();
+    return m_transfer;
 }
 
 std::shared_ptr<device_copy> 
-host_device::create_device_copy_shared()
+host_device::create_device_copy()
 {
-    return std::make_shared<host_transfer>();
+    return m_transfer;
 }
 
-std::unique_ptr<device_event> host_device::create_device_event()
+std::shared_ptr<device_event> host_device::create_device_event()
 {
-    return std::make_unique<host_event>();
-}
-
-std::shared_ptr<device_event> host_device::create_device_event_shared()
-{
-    return std::make_shared<host_event>();
-}
-
-std::unique_ptr<device_to_host_event> 
-host_device::create_device_to_host_event()
-{
-    return std::make_unique<host_event>();
+    return m_event;
 }
 
 std::shared_ptr<device_to_host_event> 
-host_device::create_device_to_host_event_shared()
+host_device::create_device_to_host_event()
 {
-    return std::make_shared<host_event>();
+    return m_event;
 }
 
 } // namespace compute

--- a/src/compute/host/host_device_backend.cpp
+++ b/src/compute/host/host_device_backend.cpp
@@ -79,23 +79,9 @@ bool host_device_backend::get_device_properties(std::size_t id,
     return result;
 }
 
-std::unique_ptr<device> 
-host_device_backend::create_device(std::size_t id,
-                                   const device_create_parameters& )
-{
-    std::unique_ptr<device> result;
-    
-    if (id == 0)
-    {
-        result = std::make_unique<host_device>();
-    }
-
-    return result;
-}
-
 std::shared_ptr<device> 
-host_device_backend::create_device_shared(std::size_t id, 
-                                          const device_create_parameters& )
+host_device_backend::create_device(std::size_t id, 
+                                   const device_create_parameters& )
 {
     std::shared_ptr<device> result;
 

--- a/src/compute/host/host_unified_memory_allocator.cpp
+++ b/src/compute/host/host_unified_memory_allocator.cpp
@@ -36,21 +36,14 @@ namespace xmipp4
 namespace compute
 {
 
-std::unique_ptr<host_unified_buffer> 
+std::shared_ptr<host_unified_buffer> 
 host_unified_memory_allocator::create_unified_buffer(std::size_t size, 
                                                      std::size_t alignment )
-{
-    return std::make_unique<default_host_unified_buffer>(size, alignment);
-}
-
-std::shared_ptr<host_unified_buffer> 
-host_unified_memory_allocator::create_unified_buffer_shared(std::size_t size, 
-                                                            std::size_t alignment )
 {
     return std::make_shared<default_host_unified_buffer>(size, alignment);
 }
 
-std::unique_ptr<device_buffer> 
+std::shared_ptr<device_buffer> 
 host_unified_memory_allocator::create_device_buffer(std::size_t size,
                                                     std::size_t alignment,
                                                     device_queue& )
@@ -58,15 +51,7 @@ host_unified_memory_allocator::create_device_buffer(std::size_t size,
     return create_unified_buffer(size, alignment);
 }
 
-std::shared_ptr<device_buffer> 
-host_unified_memory_allocator::create_device_buffer_shared(std::size_t size,
-                                                           std::size_t alignment,
-                                                           device_queue& )
-{
-    return create_unified_buffer_shared(size, alignment);
-}
-
-std::unique_ptr<host_buffer> 
+std::shared_ptr<host_buffer> 
 host_unified_memory_allocator::create_host_buffer(std::size_t size,
                                                   std::size_t alignment,
                                                   device_queue& )
@@ -75,25 +60,10 @@ host_unified_memory_allocator::create_host_buffer(std::size_t size,
 }
 
 std::shared_ptr<host_buffer> 
-host_unified_memory_allocator::create_host_buffer_shared(std::size_t size,
-                                                         std::size_t alignment,
-                                                         device_queue& )
-{
-    return create_unified_buffer_shared(size, alignment);
-}
-
-std::unique_ptr<host_buffer> 
 host_unified_memory_allocator::create_host_buffer(std::size_t size,
                                                   std::size_t alignment )
 {
     return create_unified_buffer(size, alignment);
-}
-
-std::shared_ptr<host_buffer> 
-host_unified_memory_allocator::create_host_buffer_shared(std::size_t size,
-                                                         std::size_t alignment )
-{
-    return create_unified_buffer_shared(size, alignment);
 }
 
 } // namespace compute

--- a/tests/unitary/src/communication/mock/mock_communicator_backend.hpp
+++ b/tests/unitary/src/communication/mock/mock_communicator_backend.hpp
@@ -44,7 +44,7 @@ public:
     MAKE_MOCK0(get_version, version (), const noexcept override);
     MAKE_MOCK0(is_available, bool (), const noexcept override);
     MAKE_MOCK0(get_priority, backend_priority (), const noexcept override);
-    MAKE_MOCK0(get_world_communicator, std::shared_ptr<communicator> (), const override);
+    MAKE_MOCK0(create_world_communicator, std::shared_ptr<communicator> (), const override);
 
 };
 

--- a/tests/unitary/src/compute/mock/mock_device_backend.hpp
+++ b/tests/unitary/src/compute/mock/mock_device_backend.hpp
@@ -46,8 +46,7 @@ public:
     MAKE_MOCK0(get_priority, backend_priority (), const noexcept override);
     MAKE_MOCK1(enumerate_devices, void (std::vector<std::size_t>&), const override);
     MAKE_MOCK2(get_device_properties, bool (std::size_t, device_properties&), const override);
-    MAKE_MOCK2(create_device, std::unique_ptr<device> (std::size_t, const device_create_parameters&), override);
-    MAKE_MOCK2(create_device_shared, std::shared_ptr<device> (std::size_t, const device_create_parameters&), override);
+    MAKE_MOCK2(create_device, std::shared_ptr<device> (std::size_t, const device_create_parameters&), override);
 
 };
 


### PR DESCRIPTION
Removed `unique_ptr` class method variants from compute to increase simplicity and avoid code duplication. Closes #124 