### PR TITLE
Fix empty argument in parse_device_index

### DIFF
--- a/include/xmipp4/core/compute/device_index.inl
+++ b/include/xmipp4/core/compute/device_index.inl
@@ -144,16 +144,25 @@ std::basic_ostream<T>& operator<<(std::basic_ostream<T> &os, const device_index 
 
 inline
 bool parse_device_index(std::string_view text, device_index &result)
-{
-    bool success = false;
+{    
+    if(text.empty())
+    {
+        return false;
+    }
 
     XMIPP4_CONST_CONSTEXPR auto separator = 
         detail::get_device_index_separator();
 
+    bool success = false;
     const auto begin = text.data();
     const auto end = begin + text.size();
     const auto ite = std::find(begin, end, separator);
-    if (ite != end)
+    if (ite == end)
+    {
+        result = device_index(text, 0);
+        success = true;
+    }
+    else if (ite != begin)
     {
         std::size_t id;
         if (std::from_chars(std::next(ite), end, id, 10).ec == std::errc())
@@ -164,11 +173,6 @@ bool parse_device_index(std::string_view text, device_index &result)
             );
             success = true;
         }
-    }
-    else
-    {
-        result = device_index(text, 0);
-        success = true;
     }
 
     return success;

--- a/include/xmipp4/core/compute/device_properties.hpp
+++ b/include/xmipp4/core/compute/device_properties.hpp
@@ -38,7 +38,7 @@ namespace compute
 class device_properties
 {
 public:
-    device_properties() = default;
+    device_properties();
     device_properties(const device_properties& other) = default;
     device_properties(device_properties&& other) = default;
     ~device_properties() = default;

--- a/include/xmipp4/core/compute/device_properties.inl
+++ b/include/xmipp4/core/compute/device_properties.inl
@@ -29,6 +29,15 @@ namespace xmipp4
 namespace compute
 {
 
+inline 
+device_properties::device_properties()
+    : m_type(device_type::unknown),
+      m_name(),
+      m_physical_location(),
+      m_total_memory_bytes(0)
+{
+}
+
 inline
 void device_properties::set_type(device_type type) noexcept
 {

--- a/tests/unitary/src/compute/test_device_index.cpp
+++ b/tests/unitary/src/compute/test_device_index.cpp
@@ -59,6 +59,10 @@ TEST_CASE( "parse invalid device index", "[device_index]" )
 {
     device_index index;
     REQUIRE( !parse_device_index("3:example", index) );
+    REQUIRE( !parse_device_index(":3", index) );
+    REQUIRE( !parse_device_index("test:", index) );
+    REQUIRE( !parse_device_index(":", index) );
+    REQUIRE( !parse_device_index("", index) );
 }
 
 TEST_CASE( "device index to ostream", "[device_index]" )


### PR DESCRIPTION
Correctly handling empty string inputs in parse_device_index