### PR TITLE
Added missing return

### DIFF
--- a/include/xmipp4/core/compute/device_type.inl
+++ b/include/xmipp4/core/compute/device_type.inl
@@ -39,6 +39,7 @@ const char* to_string(device_type type) noexcept
     case device_type::gpu: return "GPU";
     case device_type::integrated_gpu: return "iGPU";
     case device_type::fpga: return "FPGA";
+    default: return "";
     }
 }
 


### PR DESCRIPTION
In theory it is not needed, but MSVC demands it.