### PR TITLE
Added the option to load builtin backends in the interface registry

### DIFF
--- a/include/xmipp4/core/communication/communicator_manager.hpp
+++ b/include/xmipp4/core/communication/communicator_manager.hpp
@@ -49,7 +49,7 @@ class communicator;
  * interface.
  * 
  */
-class communicator_manager
+class communicator_manager final
     : public interface_manager
 {
 public:
@@ -63,6 +63,9 @@ public:
     operator=(const communicator_manager &other) = delete;
     XMIPP4_CORE_API communicator_manager& 
     operator=(communicator_manager &&other) noexcept;
+
+    XMIPP4_CORE_API
+    void load_builtin_backends() override;
 
     /**
      * @brief Register a new implementation.

--- a/include/xmipp4/core/communication/communicator_manager.hpp
+++ b/include/xmipp4/core/communication/communicator_manager.hpp
@@ -65,7 +65,7 @@ public:
     operator=(communicator_manager &&other) noexcept;
 
     XMIPP4_CORE_API
-    void load_builtin_backends() override;
+    void register_builtin_backends() override;
 
     /**
      * @brief Register a new implementation.

--- a/include/xmipp4/core/communication/communicator_manager.hpp
+++ b/include/xmipp4/core/communication/communicator_manager.hpp
@@ -57,7 +57,7 @@ public:
     communicator_manager(const communicator_manager &other) = delete;
     XMIPP4_CORE_API 
     communicator_manager(communicator_manager &&other) noexcept;
-    XMIPP4_CORE_API virtual ~communicator_manager();
+    XMIPP4_CORE_API ~communicator_manager() override;
 
     communicator_manager& 
     operator=(const communicator_manager &other) = delete;

--- a/include/xmipp4/core/compute/device_manager.hpp
+++ b/include/xmipp4/core/compute/device_manager.hpp
@@ -52,7 +52,7 @@ class device_create_parameters;
  * @brief Centralize multiple device_backends.
  * 
  */
-class device_manager
+class device_manager final
     : public interface_manager
 {
 public:
@@ -63,6 +63,9 @@ public:
 
     device_manager& operator=(const device_manager &other) = delete;
     XMIPP4_CORE_API device_manager& operator=(device_manager &&other) noexcept;
+
+    XMIPP4_CORE_API
+    virtual void load_builtin_backends() override;
 
     /**
      * @brief Register a new device backend.

--- a/include/xmipp4/core/compute/device_manager.hpp
+++ b/include/xmipp4/core/compute/device_manager.hpp
@@ -59,13 +59,13 @@ public:
     XMIPP4_CORE_API device_manager();
     device_manager(const device_manager &other) = delete;
     XMIPP4_CORE_API device_manager(device_manager &&other) noexcept;
-    XMIPP4_CORE_API virtual ~device_manager();
+    XMIPP4_CORE_API ~device_manager() override;
 
     device_manager& operator=(const device_manager &other) = delete;
     XMIPP4_CORE_API device_manager& operator=(device_manager &&other) noexcept;
 
     XMIPP4_CORE_API
-    virtual void register_builtin_backends() override;
+    void register_builtin_backends() override;
 
     /**
      * @brief Register a new device backend.

--- a/include/xmipp4/core/compute/device_manager.hpp
+++ b/include/xmipp4/core/compute/device_manager.hpp
@@ -65,7 +65,7 @@ public:
     XMIPP4_CORE_API device_manager& operator=(device_manager &&other) noexcept;
 
     XMIPP4_CORE_API
-    virtual void load_builtin_backends() override;
+    virtual void register_builtin_backends() override;
 
     /**
      * @brief Register a new device backend.

--- a/include/xmipp4/core/interface_manager.hpp
+++ b/include/xmipp4/core/interface_manager.hpp
@@ -55,6 +55,17 @@ public:
     interface_manager& operator=(const interface_manager& other) = default;
     interface_manager& operator=(interface_manager&& other) = default;
 
+    /**
+     * @brief Load backends bundled with the core.access_flag_bits
+     * 
+     * This usually loads fallaback implementations that are always 
+     * available although they may not be the most efficient or performant.
+     * The loaded backend(s) depend on the implementation of the specific
+     * interface.
+     * 
+     */
+    virtual void load_builtin_backends() = 0;
+
 };
 
 } // namespace xmipp4

--- a/include/xmipp4/core/interface_manager.hpp
+++ b/include/xmipp4/core/interface_manager.hpp
@@ -56,7 +56,7 @@ public:
     interface_manager& operator=(interface_manager&& other) = default;
 
     /**
-     * @brief Load backends bundled with the core.access_flag_bits
+     * @brief Register backends bundled with the core.access_flag_bits
      * 
      * This usually loads fallaback implementations that are always 
      * available although they may not be the most efficient or performant.
@@ -64,7 +64,7 @@ public:
      * interface.
      * 
      */
-    virtual void load_builtin_backends() = 0;
+    virtual void register_builtin_backends() = 0;
 
 };
 

--- a/include/xmipp4/core/interface_registry.hpp
+++ b/include/xmipp4/core/interface_registry.hpp
@@ -53,13 +53,13 @@ public:
     /**
      * @brief Construct a new interface registry object.
      * 
-     * @param load_builtin_backends This parameters controls whether the
+     * @param register_builtin_backends This parameters controls whether the
      * interface registry should load the backends bundled with the
      * core.
      * 
      */
     XMIPP4_CORE_API 
-    explicit interface_registry(bool load_builtin_backends = true);
+    explicit interface_registry(bool register_builtin_backends = true);
     interface_registry(const interface_registry& other) = delete;
     XMIPP4_CORE_API interface_registry(interface_registry&& other) noexcept;
     XMIPP4_CORE_API ~interface_registry();

--- a/include/xmipp4/core/interface_registry.hpp
+++ b/include/xmipp4/core/interface_registry.hpp
@@ -50,7 +50,16 @@ namespace xmipp4
 class interface_registry
 {
 public:
-    XMIPP4_CORE_API interface_registry();
+    /**
+     * @brief Construct a new interface registry object.
+     * 
+     * @param load_builtin_backends This parameters controls whether the
+     * interface registry should load the backends bundled with the
+     * core.
+     * 
+     */
+    XMIPP4_CORE_API 
+    explicit interface_registry(bool load_builtin_backends = true);
     interface_registry(const interface_registry& other) = delete;
     XMIPP4_CORE_API interface_registry(interface_registry&& other) noexcept;
     XMIPP4_CORE_API ~interface_registry();

--- a/src/communication/communicator_manager.cpp
+++ b/src/communication/communicator_manager.cpp
@@ -28,8 +28,9 @@
 
 #include <xmipp4/core/communication/communicator_manager.hpp>
 
-#include <xmipp4/core/communication/communicator_backend.hpp>
 #include <xmipp4/core/exceptions/ambiguous_backend_error.hpp>
+#include <xmipp4/core/communication/communicator_backend.hpp>
+#include <xmipp4/core/communication/dummy/dummy_communicator_backend.hpp>
 
 #include <tuple>
 #include <vector>
@@ -175,6 +176,11 @@ communicator_manager&
 communicator_manager::operator=(communicator_manager&& other) noexcept = default;
 
 
+
+void communicator_manager::load_builtin_backends()
+{
+    dummy_communicator_backend::register_at(*this);
+}
 
 bool communicator_manager::register_backend(std::unique_ptr<communicator_backend> backend)
 {

--- a/src/communication/communicator_manager.cpp
+++ b/src/communication/communicator_manager.cpp
@@ -177,7 +177,7 @@ communicator_manager::operator=(communicator_manager&& other) noexcept = default
 
 
 
-void communicator_manager::load_builtin_backends()
+void communicator_manager::register_builtin_backends()
 {
     dummy_communicator_backend::register_at(*this);
 }

--- a/src/compute/device_manager.cpp
+++ b/src/compute/device_manager.cpp
@@ -112,7 +112,7 @@ device_manager&
 device_manager::operator=(device_manager &&other) noexcept = default;
 
 
-void device_manager::load_builtin_backends()
+void device_manager::register_builtin_backends()
 {
     host_device_backend::register_at(*this);
 }

--- a/src/compute/device_manager.cpp
+++ b/src/compute/device_manager.cpp
@@ -29,6 +29,7 @@
 #include <xmipp4/core/compute/device_manager.hpp>
 
 #include <xmipp4/core/compute/device_backend.hpp>
+#include <xmipp4/core/compute/host/host_device_backend.hpp>
 
 #include <unordered_map>
 
@@ -111,6 +112,10 @@ device_manager&
 device_manager::operator=(device_manager &&other) noexcept = default;
 
 
+void device_manager::load_builtin_backends()
+{
+    host_device_backend::register_at(*this);
+}
 
 bool device_manager::register_backend(std::unique_ptr<device_backend> backend)
 {

--- a/src/interface_registry.cpp
+++ b/src/interface_registry.cpp
@@ -42,7 +42,7 @@ namespace xmipp4
 class interface_registry::implementation
 {
 public:
-    implementation(bool register_builtin_backends)
+    explicit implementation(bool register_builtin_backends)
         : m_register_builtin_backends(register_builtin_backends)
     {
     }

--- a/src/interface_registry.cpp
+++ b/src/interface_registry.cpp
@@ -42,7 +42,11 @@ namespace xmipp4
 class interface_registry::implementation
 {
 public:
-    implementation() = default;
+    implementation(bool load_builtin_backends)
+        : m_load_builtin_backends(load_builtin_backends)
+    {
+    }
+
     ~implementation() = default;
 
     interface_manager* get_interface_manager(std::type_index type)
@@ -61,6 +65,11 @@ public:
     void create_interface_manager(std::type_index type,
                                   std::unique_ptr<interface_manager> manager )
     {
+        if (m_load_builtin_backends)
+        {
+            manager->load_builtin_backends();
+        }
+
         m_interfaces.emplace(
             type, std::move(manager)
         );
@@ -70,11 +79,15 @@ private:
     using registry_type = 
         std::unordered_map<std::type_index, std::unique_ptr<interface_manager>>;
 
+    bool m_load_builtin_backends;
     registry_type m_interfaces;
 
 };
 
-interface_registry::interface_registry() = default;
+interface_registry::interface_registry(bool load_builtin_backends)
+    : m_implementation(load_builtin_backends)
+{
+}
 
 interface_registry::interface_registry(interface_registry&& other) noexcept = default;
 

--- a/src/interface_registry.cpp
+++ b/src/interface_registry.cpp
@@ -42,8 +42,8 @@ namespace xmipp4
 class interface_registry::implementation
 {
 public:
-    implementation(bool load_builtin_backends)
-        : m_load_builtin_backends(load_builtin_backends)
+    implementation(bool register_builtin_backends)
+        : m_register_builtin_backends(register_builtin_backends)
     {
     }
 
@@ -65,9 +65,9 @@ public:
     void create_interface_manager(std::type_index type,
                                   std::unique_ptr<interface_manager> manager )
     {
-        if (m_load_builtin_backends)
+        if (m_register_builtin_backends)
         {
-            manager->load_builtin_backends();
+            manager->register_builtin_backends();
         }
 
         m_interfaces.emplace(
@@ -79,13 +79,13 @@ private:
     using registry_type = 
         std::unordered_map<std::type_index, std::unique_ptr<interface_manager>>;
 
-    bool m_load_builtin_backends;
+    bool m_register_builtin_backends;
     registry_type m_interfaces;
 
 };
 
-interface_registry::interface_registry(bool load_builtin_backends)
-    : m_implementation(load_builtin_backends)
+interface_registry::interface_registry(bool register_builtin_backends)
+    : m_implementation(register_builtin_backends)
 {
 }
 

--- a/tests/unitary/src/mock/mock_interface_manager.hpp
+++ b/tests/unitary/src/mock/mock_interface_manager.hpp
@@ -1,3 +1,5 @@
+#pragma once
+
 /***************************************************************************
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -19,27 +21,25 @@
  ***************************************************************************/
 
 /**
- * @file test_interface_registry.cpp
+ * @file interface_manager.cpp
  * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Tests for interface_registry.hpp
- * @date 2024-10-28
- * 
+ * @brief Mock for interface_manager interface.
+ * @date 2025-03-27
  */
 
-#include <xmipp4/core/interface_registry.hpp>
+#include <xmipp4/core/interface_manager.hpp>
 
-#include "mock/mock_interface_manager.hpp"
+#include <trompeloeil.hpp>
 
-#include <catch2/catch_test_macros.hpp>
-#include <trompeloeil/matcher/any.hpp>
-
-using namespace xmipp4;
-
-TEST_CASE( "get_interface_manager should always return the same instance", "[interface_registry]" ) 
+namespace xmipp4
 {
-    interface_registry registry(false);
 
-    auto& manager1 = registry.get_interface_manager<mock_interface_manager>();
-    auto& manager2 = registry.get_interface_manager<mock_interface_manager>();
-    REQUIRE( &manager1 == &manager2 );
-}
+class mock_interface_manager final
+    : public interface_manager
+{
+public:
+    MAKE_MOCK0(register_builtin_backends, void(), override);
+
+};
+
+} // namespace xmipp4


### PR DESCRIPTION
With this change, `InterfaceRegistry` may be requested to opt-in builtin/fallback backends (default behavior)