### PR TITLE
Disable testing by default in pip installation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,3 +63,4 @@ cmake.build-type = "Release"
 [tool.scikit-build.cmake.define]
 XMIPP4_CORE_BUILD_SPDLOG = {env="XMIPP4_CORE_BUILD_SPDLOG", default="ON"}
 XMIPP4_CORE_BUILD_HALF = {env="XMIPP4_CORE_BUILD_HALF", default="ON"}
+BUILD_TESTING = "OFF"


### PR DESCRIPTION
Avoids compiling testing infrastructure with pip unless it is manually required. As a result, compile times are faster