### PR TITLE
Generate tag & GitHub release

### DIFF
--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -1,6 +1,9 @@
 name: Generate new tag & GitHub release
 on:
   workflow_dispatch:
+  
+  push:
+    branches: [ ms_generate_release ]
 
 jobs:
   tag-and-release:

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -1,0 +1,32 @@
+name: Generate new tag & GitHub release
+on:
+  workflow_dispatch:
+
+jobs:
+  tag-and-release:
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Retrieve tag name, release name & changelog
+      id: variables
+      run: |
+        python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])"
+        echo "TAG_NAME=$(python3 -c \"import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])\")" >> $GITHUB_OUTPUT
+      
+    - name: Generate tag
+        
+      id: tag_version
+      uses: mathieudutour/github-tag-action@v6.2
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        custom_tag: ${{ steps.variables.outputs.TAG_NAME }}
+        tag_prefix: ''
+        
+    - name: Create a GitHub release
+      uses: ncipollo/release-action@v1
+      with:
+        tag: ${{ steps.tag_version.outputs.new_tag }}
+        name: ${{ steps.variables.outputs.TAG_NAME }}

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -14,7 +14,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Retrieve tag name, release name & changelog
-      id: variables
+      id: version
       run: |
         export TAG_NAME=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
         echo "TAG_NAME=$TAG_NAME" >> $GITHUB_OUTPUT
@@ -24,11 +24,11 @@ jobs:
       uses: mathieudutour/github-tag-action@v6.2
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        custom_tag: ${{ steps.variables.outputs.TAG_NAME }}
+        custom_tag: ${{ steps.version.outputs.TAG_NAME }}
         tag_prefix: ''
         
     - name: Create a GitHub release
       uses: ncipollo/release-action@v1
       with:
         tag: ${{ steps.tag_version.outputs.new_tag }}
-        name: ${{ steps.variables.outputs.TAG_NAME }}
+        name: ${{ steps.version.outputs.TAG_NAME }}

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -1,9 +1,6 @@
 name: Generate new tag & GitHub release
 on:
   workflow_dispatch:
-  
-  push:
-    branches: [ ms_generate_release ]
 
 jobs:
   tag-and-release:

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -18,6 +18,7 @@ jobs:
       run: |
         export TAG_NAME=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
         echo "TAG_NAME=$TAG_NAME" >> $GITHUB_OUTPUT
+        echo "Version: $TAG_NAME"
       
     - name: Generate tag
       id: tag_version

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -33,3 +33,4 @@ jobs:
       with:
         tag: ${{ steps.tag_version.outputs.new_tag }}
         name: ${{ steps.version.outputs.TAG_NAME }}
+        body: ${{ steps.tag_version.outputs.changelog }}

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -16,11 +16,11 @@ jobs:
     - name: Retrieve tag name, release name & changelog
       id: variables
       run: |
-        python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])"
+        export TAG_NAME=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
+        echo $TAG_NAME
         echo "TAG_NAME=$(python3 -c \"import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])\")" >> $GITHUB_OUTPUT
       
     - name: Generate tag
-        
       id: tag_version
       uses: mathieudutour/github-tag-action@v6.2
       with:

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -17,8 +17,7 @@ jobs:
       id: variables
       run: |
         export TAG_NAME=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
-        echo $TAG_NAME
-        echo "TAG_NAME=$(python3 -c \"import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])\")" >> $GITHUB_OUTPUT
+        echo "TAG_NAME=$TAG_NAME" >> $GITHUB_OUTPUT
       
     - name: Generate tag
       id: tag_version


### PR DESCRIPTION
This workflow will generate a tag & a GitHub release when manually triggered, starting the release process, as this release generation should itself trigger after it the wheel generation & distribution system.

Note: The project's version is retrieved using a python library capable of reading the `pyproject.toml` file to access the version field.