### PR TITLE
Reduced verbosity while keeping installation log

### DIFF
--- a/.github/workflows/build-and-test-pip.yml
+++ b/.github/workflows/build-and-test-pip.yml
@@ -26,6 +26,6 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install xmipp4-core with pip
-        run: pip install . -vvv
+        run: pip install . -v
 
       # TODO run tests


### PR DESCRIPTION
This will reduce the complexity of the log, while still keeping the important parts we want to see (the compilation/installation of the project).