### PR TITLE
Use composite for release variables retrieval

### DIFF
--- a/.github/composites/release-variables/action.yml
+++ b/.github/composites/release-variables/action.yml
@@ -1,0 +1,43 @@
+name: "Check user authorization"
+description: "Checks if the calling user has enough permission to perform action"
+
+outputs:
+  tag_name:
+    description: "Name of the tag, in the format X.Y.Z"
+    value: ${{ steps.tag_name.outputs.tag_name }}
+  release_name:
+    description: "Name of the release, in the format vX.Y.Z"
+    value: ${{ steps.release_name.outputs.release_name }}
+  changelog:
+    description: "Body of the changelog"
+    value: ${{ steps.changelog.outputs.changelog }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Retrieve tag name
+      id: tag_name
+      shell: bash
+      run: |
+        export TAG_NAME=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
+        echo "tag_name=$TAG_NAME" >> $GITHUB_OUTPUT
+        echo "Version: $TAG_NAME"
+    
+    - name: Retrieve release name
+      id: release_name
+      shell: bash
+      env:
+        TAG_NAME: ${{ steps.tag_name.outputs.tag_name }}
+      run: |
+        export RELEASE_NAME="v$TAG_NAME"
+        echo "release_name=$RELEASE_NAME" >> $GITHUB_OUTPUT
+        echo "Release name: $RELEASE_NAME"
+
+    - name: Retrieve changelog
+      id: changelog
+      shell: bash
+      run: |
+        export CHANGELOG_BODY=$(awk '/# /{if (found) exit} {if (/# /) found=1; else if (found) print}' CHANGELOG.md)
+        echo "changelog<<EOF" >> $GITHUB_OUTPUT
+        echo "$changelog" >> $GITHUB_OUTPUT
+        echo "EOF" >> $GITHUB_OUTPUT

--- a/.github/composites/release-variables/action.yml
+++ b/.github/composites/release-variables/action.yml
@@ -41,3 +41,4 @@ runs:
         echo "changelog<<EOF" >> $GITHUB_OUTPUT
         echo "$changelog" >> $GITHUB_OUTPUT
         echo "EOF" >> $GITHUB_OUTPUT
+        echo "Changelog: $CHANGELOG_BODY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,6 @@ name: Generate new release
 on:
   workflow_dispatch:
 
-  pull_request:
-
 jobs:
   tag_and_release:
     name: Generate new tag & GitHub release
@@ -38,9 +36,6 @@ jobs:
         name: ${{ steps.variables.outputs.RELEASE_NAME }}
         body: ${{ steps.variables.outputs.CHANGELOG_BODY }}
     
-    - name: Fail
-      run: exit 1
-
   build_wheels:
     name: Build wheels for ${{ matrix.os }} (${{ matrix.architectures }})
     needs: [tag_and_release]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,9 @@ jobs:
         tag: ${{ steps.tag_version.outputs.new_tag }}
         name: ${{ steps.variables.outputs.RELEASE_NAME }}
         body: ${{ steps.variables.outputs.CHANGELOG_BODY }}
+    
+    - name: Fail
+      run: exit 1
 
   build_wheels:
     name: Build wheels for ${{ matrix.os }} (${{ matrix.architectures }})

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,19 +19,7 @@ jobs:
 
     - name: Retrieve tag name, release name & changelog
       id: variables
-      run: |
-        export TAG_NAME=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
-        echo "TAG_NAME=$TAG_NAME" >> $GITHUB_OUTPUT
-        echo "Version: $TAG_NAME"
-        
-        export RELEASE_NAME="v$TAG_NAME"
-        echo "RELEASE_NAME=$RELEASE_NAME" >> $GITHUB_OUTPUT
-        echo "Release name: $RELEASE_NAME"
-
-        export CHANGELOG_BODY=$(awk '/# /{if (found) exit} {if (/# /) found=1; else if (found) print}' CHANGELOG.md)
-        echo "CHANGELOG_BODY<<EOF" >> $GITHUB_OUTPUT
-        echo "$CHANGELOG_BODY" >> $GITHUB_OUTPUT
-        echo "EOF" >> $GITHUB_OUTPUT
+      uses: ./.github/composites/release-variables
     
     - name: Generate tag
       id: tag_version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,8 @@ name: Generate new release
 on:
   workflow_dispatch:
 
+  pull_request:
+
 jobs:
   tag_and_release:
     name: Generate new tag & GitHub release


### PR DESCRIPTION
I think it makes sense because every plugin will follow the same steps when generating tag & release (maybe we could even get the whole job into a composite in the near future).