### PR TITLE
Call composite as external

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       uses: actions/checkout@v4
     
     - name: Check authorisation level of dispatching user
-      uses: ./.github/composites/authorize-user
+      uses: gigabit-clowns/xmipp4-core/.github/composites/authorize-user@main
       with:
         allowed_roles: "admin maintain"
         github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This is needed because, when the reusable workflow is called from an external repository, the relative path to the composite will be interpreted as a relative call to the calling repository.

Therefore, this workflow needs to call the composite already as an external caller would to avoid such issue.