### PR TITLE
Emitting debug trace instead of warning when there is no plugin directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,14 +196,6 @@ else()
 	set(XMIPP4_PLUGIN_INSTALL_DIR ${CMAKE_INSTALL_LIBDIR}/xmipp4-plugins)
 endif()
 set(XMIPP4_PLUGIN_INSTALL_DIR ${XMIPP4_PLUGIN_INSTALL_DIR} CACHE PATH "Directory where the xmipp4 plugins are installed")
-file(
-	WRITE ${CMAKE_CURRENT_BINARY_DIR}/.placeholder 
-	"This file is here to prevent deletion of the plugin directory"
-)
-install(
-	FILES ${CMAKE_CURRENT_BINARY_DIR}/.placeholder 
-	DESTINATION ${XMIPP4_PLUGIN_INSTALL_DIR} 
-)
 
 configure_package_config_file(
   	${PROJECT_SOURCE_DIR}/cmake/config/config.cmake.in

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,6 +196,14 @@ else()
 	set(XMIPP4_PLUGIN_INSTALL_DIR ${CMAKE_INSTALL_LIBDIR}/xmipp4-plugins)
 endif()
 set(XMIPP4_PLUGIN_INSTALL_DIR ${XMIPP4_PLUGIN_INSTALL_DIR} CACHE PATH "Directory where the xmipp4 plugins are installed")
+file(
+	WRITE ${CMAKE_CURRENT_BINARY_DIR}/.placeholder 
+	"This file is here to prevent deletion of the plugin directory"
+)
+install(
+	FILES ${CMAKE_CURRENT_BINARY_DIR}/.placeholder 
+	DESTINATION ${XMIPP4_PLUGIN_INSTALL_DIR} 
+)
 
 configure_package_config_file(
   	${PROJECT_SOURCE_DIR}/cmake/config/config.cmake.in

--- a/src/plugin_manager.cpp
+++ b/src/plugin_manager.cpp
@@ -178,9 +178,17 @@ void discover_plugins(const std::string& directory, plugin_manager &manager)
 
     for (const auto& entry : iterator) 
     {
+        const auto path = entry.path();
+        const auto filename = path.filename().string();
+        if( filename.starts_with(".") )
+        {
+            // Skip hidden files (e.g. .placeholder)
+            continue;
+        }
+
         try
         {
-            manager.load_plugin(entry.path().string());
+            manager.load_plugin(path.string());
         }
         catch(const plugin_load_error& error)
         {

--- a/src/plugin_manager.cpp
+++ b/src/plugin_manager.cpp
@@ -169,7 +169,7 @@ void discover_plugins(const std::string& directory, plugin_manager &manager)
     }
     catch(const ghc::filesystem::filesystem_error& e)
     {
-        XMIPP4_LOG_WARN(
+        XMIPP4_LOG_DEBUG(
             "Failed to open plugin directory {}: {}", 
             directory, 
             e.what()
@@ -178,17 +178,9 @@ void discover_plugins(const std::string& directory, plugin_manager &manager)
 
     for (const auto& entry : iterator) 
     {
-        const auto path = entry.path();
-        const auto filename = path.filename().string();
-        if( filename.starts_with(".") )
-        {
-            // Skip hidden files (e.g. .placeholder)
-            continue;
-        }
-
         try
         {
-            manager.load_plugin(path.string());
+            manager.load_plugin(entry.path().string());
         }
         catch(const plugin_load_error& error)
         {


### PR DESCRIPTION
This prevents a warning when trying to discover plugins on an installation without plugins. Debug traces are silenced unless explicitly requesting to not to do so