### PR TITLE
Only add wheel files

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -185,7 +185,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: github.event_name == 'workflow_dispatch' || github.event_name == 'push' && github.event.ref == 'refs/heads/main'
+    if: github.event_name == 'push' && github.event.ref == 'refs/heads/main'
     env:
       TAG_NAME: "development"
     steps:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -185,7 +185,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: github.event_name == 'push' && github.event.ref == 'refs/heads/main'
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'push' && github.event.ref == 'refs/heads/main'
     env:
       TAG_NAME: "development"
     steps:
@@ -203,7 +203,7 @@ jobs:
         run: |
           git config --global user.name 'GitHub Actions'
           git config --global user.email 'action@github.com'
-          git add dist
+          git add *.whl
           git commit -m "Add pre-built binaries"
           git tag -fa $TAG_NAME -m 'Update development tag with main branch'
           git push origin $TAG_NAME --force


### PR DESCRIPTION
Having nested folders with non-wheel files was causing issues with pip.
The two possible solutions where:
- Manually add a search param for each nested folder (`--find-links=dist/linux-64`, `--find-links=dist/osx-arm64`)
- Remove the nested folders

Since the nested folders only contained binaries for conda, and this solution is specifically targeted for a local pip installation, and also it is a temporary solution, i opted for the second solution, which is cleaner, and simpler.