### PR TITLE
Creating images for manylinux 2.28 and deprecated binaries for x86 

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,7 +38,7 @@ jobs:
           CIBW_ARCHS: "${{ matrix.architectures }}"
           CIBW_BUILD: "cp313-*" # Python agnostic, pick any version
           CIBW_BUILD_VERBOSITY: 1
-          CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28 # TODO remove when it becames default
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28 # TODO remove when it becomes default
           CIBW_MANYLINUX_PYPY_AARCH64_IMAGE: manylinux_2_28 # TODO remove when it becomes default
       
       - name: Upload wheels


### PR DESCRIPTION
manylinux 2.28 introduces CXX11 ABI, which becomes handy for downstream workflows.