### PR TITLE
Substitute verbose headers with SPDX identifier for lincense

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,25 +1,3 @@
-#***************************************************************************
-# Authors:     Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-# 02111-1307  USA
-#
-#  All comments concerning this program package may be sent to the
-#  e-mail address 'xmipp@cnb.csic.es'
-# ***************************************************************************
-
 HeaderFilterRegex: 'xmipp4/core/.*'
 Checks: >
   -*,

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,25 +1,3 @@
-#***************************************************************************
-# Authors:     Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-# 02111-1307  USA
-#
-#  All comments concerning this program package may be sent to the
-#  e-mail address 'xmipp@cnb.csic.es'
-# ***************************************************************************
-
 cmake_minimum_required(VERSION 3.16)
 
 # Define the project

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,6 @@ else()
 	)
 endif()
 
-
 # Find all source and header files
 file(
 	GLOB_RECURSE 
@@ -117,7 +116,6 @@ target_link_libraries(
 		ghc_filesystem # Eventually replace by std::filesystem (C++17)
 		${CMAKE_DL_LIBS}
 )
-
 
 # Set up clang-tidy
 if(XMIPP4_CORE_LINT_CLANG_TIDY)

--- a/cmake/config/config.cmake.in
+++ b/cmake/config/config.cmake.in
@@ -1,25 +1,3 @@
-#***************************************************************************
-# Authors:     Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-# 02111-1307  USA
-#
-#  All comments concerning this program package may be sent to the
-#  e-mail address 'xmipp@cnb.csic.es'
-# ***************************************************************************
-
 @PACKAGE_INIT@
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/modules)

--- a/cmake/modules/Findhalf.cmake
+++ b/cmake/modules/Findhalf.cmake
@@ -1,25 +1,3 @@
-#***************************************************************************
-# Authors:     Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-# 02111-1307  USA
-#
-#  All comments concerning this program package may be sent to the
-#  e-mail address 'xmipp@cnb.csic.es'
-# ***************************************************************************
-
 cmake_minimum_required(VERSION 3.12)
 
 include(FindPackageHandleStandardArgs)

--- a/cmake/modules/fetch_ghc_filesystem.cmake
+++ b/cmake/modules/fetch_ghc_filesystem.cmake
@@ -1,25 +1,3 @@
-#***************************************************************************
-# Authors:     Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-# 02111-1307  USA
-#
-#  All comments concerning this program package may be sent to the
-#  e-mail address 'xmipp@cnb.csic.es'
-# ***************************************************************************
-
 cmake_minimum_required(VERSION 3.12)
 
 include(FetchContent)

--- a/cmake/modules/fetch_half.cmake
+++ b/cmake/modules/fetch_half.cmake
@@ -1,25 +1,3 @@
-#***************************************************************************
-# Authors:     Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-# 02111-1307  USA
-#
-#  All comments concerning this program package may be sent to the
-#  e-mail address 'xmipp@cnb.csic.es'
-# ***************************************************************************
-
 cmake_minimum_required(VERSION 3.12)
 
 include(FetchContent)

--- a/cmake/modules/fetch_spdlog.cmake
+++ b/cmake/modules/fetch_spdlog.cmake
@@ -1,25 +1,3 @@
-#***************************************************************************
-# Authors:     Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-# 02111-1307  USA
-#
-#  All comments concerning this program package may be sent to the
-#  e-mail address 'xmipp@cnb.csic.es'
-# ***************************************************************************
-
 cmake_minimum_required(VERSION 3.12)
 
 include(FetchContent)

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -1,25 +1,3 @@
-#***************************************************************************
-# Authors:     Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-# 02111-1307  USA
-#
-#  All comments concerning this program package may be sent to the
-#  e-mail address 'xmipp@cnb.csic.es'
-# ***************************************************************************
-
 cmake_minimum_required(VERSION 3.12)
 
 add_subdirectory(doxygen)

--- a/doc/doxygen/CMakeLists.txt
+++ b/doc/doxygen/CMakeLists.txt
@@ -1,25 +1,3 @@
-#***************************************************************************
-# Authors:     Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-# 02111-1307  USA
-#
-#  All comments concerning this program package may be sent to the
-#  e-mail address 'xmipp@cnb.csic.es'
-# ***************************************************************************
-
 cmake_minimum_required(VERSION 3.12)
 
 find_package(Doxygen REQUIRED)

--- a/doc/templates/source/example_enum.hpp
+++ b/doc/templates/source/example_enum.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file example_enum.hpp

--- a/doc/templates/source/example_enum.hpp
+++ b/doc/templates/source/example_enum.hpp
@@ -2,14 +2,6 @@
 
 #pragma once
 
-/**
- * @file example_enum.hpp
- * @author Your Name (yourname@yourdomain.tld)
- * @brief Provides example_enum
- * @date Today (YYYY/MM/DD)
- * 
- */
-
 #include "platform/constexpr.hpp"
 
 #include <string_view>

--- a/doc/templates/source/example_enum.inl
+++ b/doc/templates/source/example_enum.inl
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 #include "example_enum.hpp"
 

--- a/doc/templates/source/example_flags.hpp
+++ b/doc/templates/source/example_flags.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 #include "platform/constexpr.hpp"
 #include "binary/flagset.hpp"

--- a/doc/templates/source/example_flags.inl
+++ b/doc/templates/source/example_flags.inl
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 #include "example_flags.hpp"
 

--- a/doc/templates/source/header.hpp
+++ b/doc/templates/source/header.hpp
@@ -2,14 +2,6 @@
 
 #pragma once
 
-/**
- * @file header.hpp
- * @author Your Name (yourname@yourdomain.tld)
- * @brief Describe the purpose of this header
- * @date Today (YYYY/MM/DD)
- * 
- */
-
 namespace xmipp4 
 {
 

--- a/doc/templates/source/header.hpp
+++ b/doc/templates/source/header.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file header.hpp

--- a/doc/templates/source/inline_source.inl
+++ b/doc/templates/source/inline_source.inl
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file inline_source.inl
- * @author Your Name (yourname@yourdomain.tld)
- * @brief Implements header.hpp
- * @date Today (YYYY/MM/DD)
- * 
- */
-
 #include "header.hpp"
 
 namespace xmipp4 

--- a/doc/templates/source/inline_source.inl
+++ b/doc/templates/source/inline_source.inl
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file inline_source.inl

--- a/doc/templates/source/source.cpp
+++ b/doc/templates/source/source.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file source.cpp

--- a/doc/templates/source/source.cpp
+++ b/doc/templates/source/source.cpp
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file source.cpp
- * @author Your Name (yourname@yourdomain.tld)
- * @brief Implements header.hpp
- * @date Today (YYYY/MM/DD)
- * 
- */
-
 #include "header.hpp"
 
 namespace xmipp4 

--- a/include/xmipp4/core/access_flags.hpp
+++ b/include/xmipp4/core/access_flags.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 #include "platform/constexpr.hpp"
 #include "binary/bit.hpp"

--- a/include/xmipp4/core/access_flags.inl
+++ b/include/xmipp4/core/access_flags.inl
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 #include "access_flags.hpp"
 

--- a/include/xmipp4/core/axis_3d.hpp
+++ b/include/xmipp4/core/axis_3d.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file axis_3d.hpp

--- a/include/xmipp4/core/axis_3d.hpp
+++ b/include/xmipp4/core/axis_3d.hpp
@@ -2,14 +2,6 @@
 
 #pragma once
 
-/**
- * @file axis_3d.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Provides axis_3d enumeration and utility functions
- * @date 2023-09-27
- * 
- */
-
 #include "platform/constexpr.hpp"
 #include "platform/attributes.hpp"
 

--- a/include/xmipp4/core/axis_3d.inl
+++ b/include/xmipp4/core/axis_3d.inl
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file axis_3d.inl

--- a/include/xmipp4/core/axis_3d.inl
+++ b/include/xmipp4/core/axis_3d.inl
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file axis_3d.inl
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of axis_3d.hpp
- * @date 2023-09-27
- * 
- */
-
 #include "axis_3d.hpp"
 
 #include "platform/assert.hpp"

--- a/include/xmipp4/core/backend.hpp
+++ b/include/xmipp4/core/backend.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file backend.hpp

--- a/include/xmipp4/core/backend.hpp
+++ b/include/xmipp4/core/backend.hpp
@@ -2,14 +2,6 @@
 
 #pragma once
 
-/**
- * @file backend.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Defines basic backend interface
- * @date 2024-10-29
- * 
- */
-
 #include "version.hpp"
 #include "backend_priority.hpp"
 #include "platform/dynamic_shared_object.h"

--- a/include/xmipp4/core/backend_manager.hpp
+++ b/include/xmipp4/core/backend_manager.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file backend_manager.hpp

--- a/include/xmipp4/core/backend_manager.hpp
+++ b/include/xmipp4/core/backend_manager.hpp
@@ -2,14 +2,6 @@
 
 #pragma once
 
-/**
- * @file backend_manager.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Defines backend_manager class
- * @date 2024-10-23
- * 
- */
-
 #include "platform/dynamic_shared_object.h"
 
 #include <string>

--- a/include/xmipp4/core/backend_manager.inl
+++ b/include/xmipp4/core/backend_manager.inl
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 #include "backend_manager.hpp"
 

--- a/include/xmipp4/core/backend_priority.hpp
+++ b/include/xmipp4/core/backend_priority.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file backend_priority.hpp

--- a/include/xmipp4/core/backend_priority.hpp
+++ b/include/xmipp4/core/backend_priority.hpp
@@ -2,14 +2,6 @@
 
 #pragma once
 
-/**
- * @file backend_priority.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Provides backend_priority enumeration and utility functions
- * @date 2023-11-20
- * 
- */
-
 #include "platform/constexpr.hpp"
 #include "platform/attributes.hpp"
 

--- a/include/xmipp4/core/backend_priority.inl
+++ b/include/xmipp4/core/backend_priority.inl
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file backend_priority.inl

--- a/include/xmipp4/core/backend_priority.inl
+++ b/include/xmipp4/core/backend_priority.inl
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file backend_priority.inl
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of backend_priority.hpp
- * @date 2024-11-20
- * 
- */
-
 #include "backend_priority.hpp"
 
 namespace xmipp4 

--- a/include/xmipp4/core/binary/bit.hpp
+++ b/include/xmipp4/core/binary/bit.hpp
@@ -2,13 +2,6 @@
 
 #pragma once
 
-/**
- * @file bit.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Utilities to perform bitwise operations on unsigned words
- * @date 2023-08-09
- */
-
 #include "../platform/constexpr.hpp"
 #include "../platform/attributes.hpp"
 

--- a/include/xmipp4/core/binary/bit.hpp
+++ b/include/xmipp4/core/binary/bit.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file bit.hpp

--- a/include/xmipp4/core/binary/bit.inl
+++ b/include/xmipp4/core/binary/bit.inl
@@ -1,12 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file bit.inl
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of bit.hpp
- * @date 2023-08-09
- */
-
 #include "bit.hpp"
 #include "../platform/cpp_features.hpp"
 

--- a/include/xmipp4/core/binary/bit.inl
+++ b/include/xmipp4/core/binary/bit.inl
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file bit.inl

--- a/include/xmipp4/core/binary/flagset.hpp
+++ b/include/xmipp4/core/binary/flagset.hpp
@@ -2,14 +2,6 @@
 
 #pragma once
 
-/**
- * @file flagset.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Provides flagset class
- * @date 2023-08-09
- * 
- */
-
 #include "../platform/attributes.hpp"
 #include "../platform/constexpr.hpp"
 

--- a/include/xmipp4/core/binary/flagset.hpp
+++ b/include/xmipp4/core/binary/flagset.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file flagset.hpp

--- a/include/xmipp4/core/binary/flagset.inl
+++ b/include/xmipp4/core/binary/flagset.inl
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file flagset.inl

--- a/include/xmipp4/core/binary/flagset.inl
+++ b/include/xmipp4/core/binary/flagset.inl
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file flagset.inl
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of flagset.hpp
- * @date 2023-08-09
- * 
- */
-
 #include "flagset.hpp"
 
 #include "bit.hpp"

--- a/include/xmipp4/core/communication/communicator.hpp
+++ b/include/xmipp4/core/communication/communicator.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file communicator.hpp

--- a/include/xmipp4/core/communication/communicator.hpp
+++ b/include/xmipp4/core/communication/communicator.hpp
@@ -2,14 +2,6 @@
 
 #pragma once
 
-/**
- * @file communicator.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Definition of the communication::communicator class
- * @date 2024-10-24
- * 
- */
-
 #include "../reduction_operation.hpp"
 #include "../span.hpp"
 #include "../memory/byte.hpp"

--- a/include/xmipp4/core/communication/communicator_backend.hpp
+++ b/include/xmipp4/core/communication/communicator_backend.hpp
@@ -2,14 +2,6 @@
 
 #pragma once
 
-/**
- * @file communicator_backend.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Defines communicator_backend interface
- * @date 2024-10-24
- * 
- */
-
 #include "../backend.hpp"
 
 #include "../platform/dynamic_shared_object.h"

--- a/include/xmipp4/core/communication/communicator_backend.hpp
+++ b/include/xmipp4/core/communication/communicator_backend.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file communicator_backend.hpp

--- a/include/xmipp4/core/communication/communicator_manager.hpp
+++ b/include/xmipp4/core/communication/communicator_manager.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file communicator_manager.hpp

--- a/include/xmipp4/core/communication/communicator_manager.hpp
+++ b/include/xmipp4/core/communication/communicator_manager.hpp
@@ -2,14 +2,6 @@
 
 #pragma once
 
-/**
- * @file communicator_manager.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Defines communicator_manager interface
- * @date 2024-10-25
- * 
- */
-
 #include <string>
 #include <vector>
 #include <memory>

--- a/include/xmipp4/core/communication/dummy/dummy_communicator.hpp
+++ b/include/xmipp4/core/communication/dummy/dummy_communicator.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file dummy_communicator.hpp

--- a/include/xmipp4/core/communication/dummy/dummy_communicator.hpp
+++ b/include/xmipp4/core/communication/dummy/dummy_communicator.hpp
@@ -2,14 +2,6 @@
 
 #pragma once
 
-/**
- * @file dummy_communicator.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Definition of the communication::dummy_communicator class
- * @date 2024-10-26
- * 
- */
-
 #include "../communicator.hpp"
 
 #include <memory>

--- a/include/xmipp4/core/communication/dummy/dummy_communicator_backend.hpp
+++ b/include/xmipp4/core/communication/dummy/dummy_communicator_backend.hpp
@@ -2,14 +2,6 @@
 
 #pragma once
 
-/**
- * @file dummy_communicator_backend.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Definition of the communication::dummy_communicator_backend class
- * @date 2024-11-20
- * 
- */
-
 #include "../communicator_backend.hpp"
 
 #include <memory>

--- a/include/xmipp4/core/communication/dummy/dummy_communicator_backend.hpp
+++ b/include/xmipp4/core/communication/dummy/dummy_communicator_backend.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file dummy_communicator_backend.hpp

--- a/include/xmipp4/core/compute/checks.hpp
+++ b/include/xmipp4/core/compute/checks.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file checks.hpp

--- a/include/xmipp4/core/compute/checks.hpp
+++ b/include/xmipp4/core/compute/checks.hpp
@@ -2,14 +2,6 @@
 
 #pragma once
 
-/**
- * @file checks.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Declaration of precondition handling routines.
- * @date 2024-11-12
- * 
- */
-
 #include "numerical_type.hpp"
 #include "copy_region.hpp"
 #include "../platform/dynamic_shared_object.h"

--- a/include/xmipp4/core/compute/copy_region.hpp
+++ b/include/xmipp4/core/compute/copy_region.hpp
@@ -2,14 +2,6 @@
 
 #pragma once
 
-/**
- * @file copy_region.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Definition of the compute::copy_region class
- * @date 2024-11-11
- * 
- */
-
 #include "../platform/constexpr.hpp"
 
 #include <cstddef>

--- a/include/xmipp4/core/compute/copy_region.hpp
+++ b/include/xmipp4/core/compute/copy_region.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file copy_region.hpp

--- a/include/xmipp4/core/compute/copy_region.inl
+++ b/include/xmipp4/core/compute/copy_region.inl
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file copy_region.inl
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of copy_region.hpp
- * @date 2024-11-11
- * 
- */
-
 #include "copy_region.hpp"
 
 namespace xmipp4 

--- a/include/xmipp4/core/compute/copy_region.inl
+++ b/include/xmipp4/core/compute/copy_region.inl
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file copy_region.inl

--- a/include/xmipp4/core/compute/cpu/cpu_device.hpp
+++ b/include/xmipp4/core/compute/cpu/cpu_device.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file cpu_device.hpp

--- a/include/xmipp4/core/compute/cpu/cpu_device.hpp
+++ b/include/xmipp4/core/compute/cpu/cpu_device.hpp
@@ -2,14 +2,6 @@
 
 #pragma once
 
-/**
- * @file cpu_device.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Defines cpu_device interface
- * @date 2024-10-29
- * 
- */
-
 #include "../device.hpp"
 
 #include "cpu_device_queue_pool.hpp"

--- a/include/xmipp4/core/compute/cpu/cpu_device_backend.hpp
+++ b/include/xmipp4/core/compute/cpu/cpu_device_backend.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file cpu_device_backend.hpp

--- a/include/xmipp4/core/compute/cpu/cpu_device_backend.hpp
+++ b/include/xmipp4/core/compute/cpu/cpu_device_backend.hpp
@@ -2,14 +2,6 @@
 
 #pragma once
 
-/**
- * @file cpu_device_backend.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Defines cpu_device_backend interface
- * @date 2024-10-29
- * 
- */
-
 #include "../device_backend.hpp"
 
 namespace xmipp4 

--- a/include/xmipp4/core/compute/cpu/cpu_device_queue.hpp
+++ b/include/xmipp4/core/compute/cpu/cpu_device_queue.hpp
@@ -2,14 +2,6 @@
 
 #pragma once
 
-/**
- * @file cpu_device_queue.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Defines cpu_device_queue interface
- * @date 2024-10-29
- * 
- */
-
 #include "../device_queue.hpp"
 
 namespace xmipp4 

--- a/include/xmipp4/core/compute/cpu/cpu_device_queue.hpp
+++ b/include/xmipp4/core/compute/cpu/cpu_device_queue.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file cpu_device_queue.hpp

--- a/include/xmipp4/core/compute/cpu/cpu_device_queue_pool.hpp
+++ b/include/xmipp4/core/compute/cpu/cpu_device_queue_pool.hpp
@@ -2,14 +2,6 @@
 
 #pragma once
 
-/**
- * @file cpu_device_queue.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Defines cpu_device_queue interface
- * @date 2024-11-27
- * 
- */
-
 #include "../device_queue_pool.hpp"
 
 #include "cpu_device_queue.hpp"

--- a/include/xmipp4/core/compute/cpu/cpu_device_queue_pool.hpp
+++ b/include/xmipp4/core/compute/cpu/cpu_device_queue_pool.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file cpu_device_queue.hpp

--- a/include/xmipp4/core/compute/cpu/cpu_event.hpp
+++ b/include/xmipp4/core/compute/cpu/cpu_event.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file cpu_event.hpp

--- a/include/xmipp4/core/compute/cpu/cpu_event.hpp
+++ b/include/xmipp4/core/compute/cpu/cpu_event.hpp
@@ -2,14 +2,6 @@
 
 #pragma once
 
-/**
- * @file cpu_event.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Defines cpu_event class.
- * @date 2024-11-13
- * 
- */
-
 #include "../device_event.hpp"
 #include "../device_to_host_event.hpp"
 

--- a/include/xmipp4/core/compute/cpu/cpu_numerical_type.hpp
+++ b/include/xmipp4/core/compute/cpu/cpu_numerical_type.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file cpu_numerical_type.hpp

--- a/include/xmipp4/core/compute/cpu/cpu_numerical_type.hpp
+++ b/include/xmipp4/core/compute/cpu/cpu_numerical_type.hpp
@@ -2,14 +2,6 @@
 
 #pragma once
 
-/**
- * @file cpu_numerical_type.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Numerical type conversions for host
- * @date 2024-11-06
- * 
- */
-
 #include "../numerical_type.hpp"
 #include "../../fixed_float.hpp"
 #include "../../platform/constexpr.hpp"

--- a/include/xmipp4/core/compute/cpu/cpu_transfer.hpp
+++ b/include/xmipp4/core/compute/cpu/cpu_transfer.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file cpu_transfer.hpp

--- a/include/xmipp4/core/compute/cpu/cpu_transfer.hpp
+++ b/include/xmipp4/core/compute/cpu/cpu_transfer.hpp
@@ -2,14 +2,6 @@
 
 #pragma once
 
-/**
- * @file cpu_transfer.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of device_host_communicator
- * @date 2024-11-06
- * 
- */
-
 #include "../device_to_host_transfer.hpp"
 #include "../host_to_device_transfer.hpp"
 #include "../device_copy.hpp"

--- a/include/xmipp4/core/compute/cpu/cpu_unified_buffer.hpp
+++ b/include/xmipp4/core/compute/cpu/cpu_unified_buffer.hpp
@@ -2,14 +2,6 @@
 
 #pragma once
 
-/**
- * @file cpu_unified_buffer.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Defines the compute::cpu_unified_buffer interface
- * @date 2024-10-29
- * 
- */
-
 #include "../device_buffer.hpp"
 #include "../host_buffer.hpp"
 

--- a/include/xmipp4/core/compute/cpu/cpu_unified_buffer.hpp
+++ b/include/xmipp4/core/compute/cpu/cpu_unified_buffer.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file cpu_unified_buffer.hpp

--- a/include/xmipp4/core/compute/cpu/cpu_unified_memory_allocator.hpp
+++ b/include/xmipp4/core/compute/cpu/cpu_unified_memory_allocator.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file cpu_unified_memory_allocator.hpp

--- a/include/xmipp4/core/compute/cpu/cpu_unified_memory_allocator.hpp
+++ b/include/xmipp4/core/compute/cpu/cpu_unified_memory_allocator.hpp
@@ -2,15 +2,6 @@
 
 #pragma once
 
-/**
- * @file cpu_unified_memory_allocator.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Defines the compute::cpu_unified_memory_allocator class
- * @date 2024-11-06
- * 
- */
-
-
 #include "../device_memory_allocator.hpp"
 #include "../host_memory_allocator.hpp"
 

--- a/include/xmipp4/core/compute/device.hpp
+++ b/include/xmipp4/core/compute/device.hpp
@@ -2,14 +2,6 @@
 
 #pragma once
 
-/**
- * @file device.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Defines the compute::device interface
- * @date 2024-10-22
- * 
- */
-
 #include <memory>
 
 #include "../platform/dynamic_shared_object.h"

--- a/include/xmipp4/core/compute/device.hpp
+++ b/include/xmipp4/core/compute/device.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file device.hpp

--- a/include/xmipp4/core/compute/device_backend.hpp
+++ b/include/xmipp4/core/compute/device_backend.hpp
@@ -2,14 +2,6 @@
 
 #pragma once
 
-/**
- * @file device_backend.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Defines device_backend interface
- * @date 2024-10-23
- * 
- */
-
 #include "device_properties.hpp"
 #include "../backend.hpp"
 #include "../platform/dynamic_shared_object.h"

--- a/include/xmipp4/core/compute/device_backend.hpp
+++ b/include/xmipp4/core/compute/device_backend.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file device_backend.hpp

--- a/include/xmipp4/core/compute/device_buffer.hpp
+++ b/include/xmipp4/core/compute/device_buffer.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file device_buffer.hpp

--- a/include/xmipp4/core/compute/device_buffer.hpp
+++ b/include/xmipp4/core/compute/device_buffer.hpp
@@ -2,14 +2,6 @@
 
 #pragma once
 
-/**
- * @file device_buffer.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Defines the compute::device_buffer interface
- * @date 2024-10-25
- * 
- */
-
 #include "../platform/dynamic_shared_object.h"
 
 #include <memory>

--- a/include/xmipp4/core/compute/device_copy.hpp
+++ b/include/xmipp4/core/compute/device_copy.hpp
@@ -2,14 +2,6 @@
 
 #pragma once
 
-/**
- * @file device_copy.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Defines the compute::device_copy interface
- * @date 2024-11-15
- * 
- */
-
 #include "copy_region.hpp"
 #include "../span.hpp"
 #include "../platform/dynamic_shared_object.h"

--- a/include/xmipp4/core/compute/device_copy.hpp
+++ b/include/xmipp4/core/compute/device_copy.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file device_copy.hpp

--- a/include/xmipp4/core/compute/device_create_parameters.hpp
+++ b/include/xmipp4/core/compute/device_create_parameters.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 #include "../platform/constexpr.hpp"
 

--- a/include/xmipp4/core/compute/device_create_parameters.inl
+++ b/include/xmipp4/core/compute/device_create_parameters.inl
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 #include "device_create_parameters.hpp"
 

--- a/include/xmipp4/core/compute/device_event.hpp
+++ b/include/xmipp4/core/compute/device_event.hpp
@@ -2,14 +2,6 @@
 
 #pragma once
 
-/**
- * @file device_event.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Defines the compute::device_event interface
- * @date 2024-11-13
- * 
- */
-
 #include "../platform/dynamic_shared_object.h"
 
 namespace xmipp4 

--- a/include/xmipp4/core/compute/device_event.hpp
+++ b/include/xmipp4/core/compute/device_event.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file device_event.hpp

--- a/include/xmipp4/core/compute/device_index.hpp
+++ b/include/xmipp4/core/compute/device_index.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file device_index.hpp

--- a/include/xmipp4/core/compute/device_index.hpp
+++ b/include/xmipp4/core/compute/device_index.hpp
@@ -2,14 +2,6 @@
 
 #pragma once
 
-/**
- * @file device_index.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Definition of the compute::device_index class
- * @date 2024-10-23
- * 
- */
-
 #include "../platform/constexpr.hpp"
 
 #include <string>

--- a/include/xmipp4/core/compute/device_index.inl
+++ b/include/xmipp4/core/compute/device_index.inl
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file device_index.inl
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of device_index.hpp
- * @date 2024-05-15
- * 
- */
-
 #include "device_index.hpp"
 
 #include <tuple>

--- a/include/xmipp4/core/compute/device_index.inl
+++ b/include/xmipp4/core/compute/device_index.inl
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file device_index.inl

--- a/include/xmipp4/core/compute/device_manager.hpp
+++ b/include/xmipp4/core/compute/device_manager.hpp
@@ -2,14 +2,6 @@
 
 #pragma once
 
-/**
- * @file device_manager.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Defines device_manager interface
- * @date 2024-10-23
- * 
- */
-
 #include "device_index.hpp"
 #include "device_properties.hpp"
 #include "device_backend.hpp"

--- a/include/xmipp4/core/compute/device_manager.hpp
+++ b/include/xmipp4/core/compute/device_manager.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file device_manager.hpp

--- a/include/xmipp4/core/compute/device_memory_allocator.hpp
+++ b/include/xmipp4/core/compute/device_memory_allocator.hpp
@@ -2,14 +2,6 @@
 
 #pragma once
 
-/**
- * @file device_memory_allocator.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Defines the compute::device_memory_allocator interface
- * @date 2024-10-31
- * 
- */
-
 #include "../platform/dynamic_shared_object.h"
 
 #include <memory>

--- a/include/xmipp4/core/compute/device_memory_allocator.hpp
+++ b/include/xmipp4/core/compute/device_memory_allocator.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file device_memory_allocator.hpp

--- a/include/xmipp4/core/compute/device_properties.hpp
+++ b/include/xmipp4/core/compute/device_properties.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 #include "device_type.hpp"
 #include "../platform/constexpr.hpp"

--- a/include/xmipp4/core/compute/device_properties.inl
+++ b/include/xmipp4/core/compute/device_properties.inl
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 #include "device_properties.hpp"
 

--- a/include/xmipp4/core/compute/device_queue.hpp
+++ b/include/xmipp4/core/compute/device_queue.hpp
@@ -2,14 +2,6 @@
 
 #pragma once
 
-/**
- * @file device_queue.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Defines the compute::device_queue interface
- * @date 2024-10-22
- * 
- */
-
 #include "../platform/dynamic_shared_object.h"
 
 namespace xmipp4 

--- a/include/xmipp4/core/compute/device_queue.hpp
+++ b/include/xmipp4/core/compute/device_queue.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file device_queue.hpp

--- a/include/xmipp4/core/compute/device_queue_pool.hpp
+++ b/include/xmipp4/core/compute/device_queue_pool.hpp
@@ -2,14 +2,6 @@
 
 #pragma once
 
-/**
- * @file device_queue_pool.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Defines the compute::device_queue_pool interface
- * @date 2024-11-27
- * 
- */
-
 #include "../platform/dynamic_shared_object.h"
 
 #include <cstddef>

--- a/include/xmipp4/core/compute/device_queue_pool.hpp
+++ b/include/xmipp4/core/compute/device_queue_pool.hpp
@@ -35,4 +35,3 @@ public:
 
 } // namespace compute
 } // namespace xmipp4
-

--- a/include/xmipp4/core/compute/device_queue_pool.hpp
+++ b/include/xmipp4/core/compute/device_queue_pool.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file device_queue_pool.hpp

--- a/include/xmipp4/core/compute/device_to_host_event.hpp
+++ b/include/xmipp4/core/compute/device_to_host_event.hpp
@@ -2,14 +2,6 @@
 
 #pragma once
 
-/**
- * @file device_to_host_event.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Defines the compute::device_to_host_event interface
- * @date 2024-11-13
- * 
- */
-
 #include "../platform/dynamic_shared_object.h"
 
 namespace xmipp4 

--- a/include/xmipp4/core/compute/device_to_host_event.hpp
+++ b/include/xmipp4/core/compute/device_to_host_event.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file device_to_host_event.hpp

--- a/include/xmipp4/core/compute/device_to_host_transfer.hpp
+++ b/include/xmipp4/core/compute/device_to_host_transfer.hpp
@@ -2,14 +2,6 @@
 
 #pragma once
 
-/**
- * @file device_to_host_transfer.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Defines the compute::device_to_host_transfer interface
- * @date 2024-11-06
- * 
- */
-
 #include "copy_region.hpp"
 #include "../span.hpp"
 #include "../platform/dynamic_shared_object.h"

--- a/include/xmipp4/core/compute/device_to_host_transfer.hpp
+++ b/include/xmipp4/core/compute/device_to_host_transfer.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file device_to_host_transfer.hpp

--- a/include/xmipp4/core/compute/device_type.hpp
+++ b/include/xmipp4/core/compute/device_type.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 #include "../platform/constexpr.hpp"
 

--- a/include/xmipp4/core/compute/device_type.inl
+++ b/include/xmipp4/core/compute/device_type.inl
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 #include "device_type.hpp"
 

--- a/include/xmipp4/core/compute/host_buffer.hpp
+++ b/include/xmipp4/core/compute/host_buffer.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file host_buffer.hpp

--- a/include/xmipp4/core/compute/host_buffer.hpp
+++ b/include/xmipp4/core/compute/host_buffer.hpp
@@ -2,14 +2,6 @@
 
 #pragma once
 
-/**
- * @file host_buffer.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Defines the compute::host_buffer interface
- * @date 2024-11-06
- * 
- */
-
 #include "copy_region.hpp"
 #include "../span.hpp"
 #include "../platform/dynamic_shared_object.h"

--- a/include/xmipp4/core/compute/host_memory_allocator.hpp
+++ b/include/xmipp4/core/compute/host_memory_allocator.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file host_memory_allocator.hpp

--- a/include/xmipp4/core/compute/host_memory_allocator.hpp
+++ b/include/xmipp4/core/compute/host_memory_allocator.hpp
@@ -2,14 +2,6 @@
 
 #pragma once
 
-/**
- * @file host_memory_allocator.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Defines the compute::host_memory_allocator interface
- * @date 2024-10-31
- * 
- */
-
 #include "../platform/dynamic_shared_object.h"
 
 #include <memory>

--- a/include/xmipp4/core/compute/host_to_device_transfer.hpp
+++ b/include/xmipp4/core/compute/host_to_device_transfer.hpp
@@ -2,14 +2,6 @@
 
 #pragma once
 
-/**
- * @file host_to_device_transfer.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Defines the compute::host_to_device_transfer interface
- * @date 2024-11-06
- * 
- */
-
 #include "copy_region.hpp"
 #include "../span.hpp"
 #include "../platform/dynamic_shared_object.h"

--- a/include/xmipp4/core/compute/host_to_device_transfer.hpp
+++ b/include/xmipp4/core/compute/host_to_device_transfer.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file host_to_device_transfer.hpp

--- a/include/xmipp4/core/compute/numerical_type.hpp
+++ b/include/xmipp4/core/compute/numerical_type.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 #include "../platform/constexpr.hpp"
 

--- a/include/xmipp4/core/compute/numerical_type.inl
+++ b/include/xmipp4/core/compute/numerical_type.inl
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 #include "numerical_type.hpp"
 

--- a/include/xmipp4/core/concurrency/detail/mutex_semaphore.hpp
+++ b/include/xmipp4/core/concurrency/detail/mutex_semaphore.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 #define XMIPP4_MUTEX_SEMAPHORE_IMPLEMENTATION
 #define XMIPP4_MUTEX_SEMAPHORE_IMPLEMENTATION_MAX_VALUE \

--- a/include/xmipp4/core/concurrency/detail/mutex_semaphore.inl
+++ b/include/xmipp4/core/concurrency/detail/mutex_semaphore.inl
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 #include "mutex_semaphore.hpp"
 

--- a/include/xmipp4/core/concurrency/detail/posix_semaphore.hpp
+++ b/include/xmipp4/core/concurrency/detail/posix_semaphore.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 #include "../../platform/operating_system.h"
 #if XMIPP4_POSIX && (_POSIX_C_SOURCE >= 200112L)

--- a/include/xmipp4/core/concurrency/detail/posix_semaphore.inl
+++ b/include/xmipp4/core/concurrency/detail/posix_semaphore.inl
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 #include "posix_semaphore.hpp"
 

--- a/include/xmipp4/core/concurrency/detail/windows_semaphore.hpp
+++ b/include/xmipp4/core/concurrency/detail/windows_semaphore.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 #include "../../platform/operating_system.h"
 #if XMIPP4_WINDOWS

--- a/include/xmipp4/core/concurrency/detail/windows_semaphore.inl
+++ b/include/xmipp4/core/concurrency/detail/windows_semaphore.inl
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 #include "windows_semaphore.hpp"
 

--- a/include/xmipp4/core/concurrency/semaphore.hpp
+++ b/include/xmipp4/core/concurrency/semaphore.hpp
@@ -1,25 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
 #pragma once
-
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
-
 
 // Detect underlying implementation
 #include "../platform/cpp_features.hpp"

--- a/include/xmipp4/core/concurrency/semaphore.inl
+++ b/include/xmipp4/core/concurrency/semaphore.inl
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 #include "semaphore.hpp"
 

--- a/include/xmipp4/core/core_version.hpp
+++ b/include/xmipp4/core/core_version.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file core_version.hpp

--- a/include/xmipp4/core/core_version.hpp
+++ b/include/xmipp4/core/core_version.hpp
@@ -2,14 +2,6 @@
 
 #pragma once
 
-/**
- * @file core_version.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Utilities for getting xmipp4-core version
- * @date 2024-03-03
- * 
- */
-
 #include "version.hpp"
 #include "platform/dynamic_shared_object.h"
 

--- a/include/xmipp4/core/exceptions/ambiguous_backend_error.hpp
+++ b/include/xmipp4/core/exceptions/ambiguous_backend_error.hpp
@@ -2,14 +2,6 @@
 
 #pragma once
 
-/**
- * @file ambiguous_backend_exception.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Definition of ambiguous_backend_error
- * @date 2024-11-20
- * 
- */
-
 #include <stdexcept>
 
 namespace xmipp4 

--- a/include/xmipp4/core/exceptions/ambiguous_backend_error.hpp
+++ b/include/xmipp4/core/exceptions/ambiguous_backend_error.hpp
@@ -19,4 +19,3 @@ class ambiguous_backend_error
 };
 
 } // namespace xmipp4
-

--- a/include/xmipp4/core/exceptions/ambiguous_backend_error.hpp
+++ b/include/xmipp4/core/exceptions/ambiguous_backend_error.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file ambiguous_backend_exception.hpp

--- a/include/xmipp4/core/exceptions/plugin_load_error.hpp
+++ b/include/xmipp4/core/exceptions/plugin_load_error.hpp
@@ -2,14 +2,6 @@
 
 #pragma once
 
-/**
- * @file plugin_load_error.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Definition of plugin_load_error
- * @date 2024-11-21
- * 
- */
-
 #include <stdexcept>
 
 namespace xmipp4 

--- a/include/xmipp4/core/exceptions/plugin_load_error.hpp
+++ b/include/xmipp4/core/exceptions/plugin_load_error.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file plugin_load_error.hpp

--- a/include/xmipp4/core/fixed_float.hpp
+++ b/include/xmipp4/core/fixed_float.hpp
@@ -2,14 +2,6 @@
 
 #pragma once
 
-/**
- * @file fixed_float.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Fixed width floating point types.
- * @date 2024-11-25
- * 
- */
-
 #include <half.hpp>
 
 namespace xmipp4

--- a/include/xmipp4/core/fixed_float.hpp
+++ b/include/xmipp4/core/fixed_float.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file fixed_float.hpp

--- a/include/xmipp4/core/image/location.hpp
+++ b/include/xmipp4/core/image/location.hpp
@@ -2,14 +2,6 @@
 
 #pragma once
 
-/**
- * @file location.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Definition of the image::location class
- * @date 2024-05-15
- * 
- */
-
 #include "../platform/constexpr.hpp"
 
 #include <string>

--- a/include/xmipp4/core/image/location.hpp
+++ b/include/xmipp4/core/image/location.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file location.hpp

--- a/include/xmipp4/core/image/location.inl
+++ b/include/xmipp4/core/image/location.inl
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file location.inl
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of location.hpp
- * @date 2024-05-15
- * 
- */
-
 #include "location.hpp"
 
 #include <tuple>

--- a/include/xmipp4/core/image/location.inl
+++ b/include/xmipp4/core/image/location.inl
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file location.inl

--- a/include/xmipp4/core/index.hpp
+++ b/include/xmipp4/core/index.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 #include <type_traits>
 #include <cstddef>

--- a/include/xmipp4/core/index.inl
+++ b/include/xmipp4/core/index.inl
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 #include "index.hpp"
 

--- a/include/xmipp4/core/interface_catalog.hpp
+++ b/include/xmipp4/core/interface_catalog.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file interface_catalog.hpp

--- a/include/xmipp4/core/interface_catalog.hpp
+++ b/include/xmipp4/core/interface_catalog.hpp
@@ -2,14 +2,6 @@
 
 #pragma once
 
-/**
- * @file interface_catalog.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Defines interface_catalog class
- * @date 2024-10-23
- * 
- */
-
 #include "backend_manager.hpp"
 #include "memory/pimpl.hpp"
 #include "platform/dynamic_shared_object.h"

--- a/include/xmipp4/core/interface_catalog.inl
+++ b/include/xmipp4/core/interface_catalog.inl
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 #include "interface_catalog.hpp"
 

--- a/include/xmipp4/core/logger.hpp
+++ b/include/xmipp4/core/logger.hpp
@@ -2,14 +2,6 @@
 
 #pragma once
 
-/**
- * @file logger.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Defines logging utilities.
- * @date 2024-11-21
- * 
- */
-
 #define XMIPP4_LOG_LEVEL_TRACE SPDLOG_LEVEL_TRACE
 #define XMIPP4_LOG_LEVEL_DEBUG SPDLOG_LEVEL_DEBUG
 #define XMIPP4_LOG_LEVEL_INFO SPDLOG_LEVEL_INFO

--- a/include/xmipp4/core/logger.hpp
+++ b/include/xmipp4/core/logger.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file logger.hpp

--- a/include/xmipp4/core/math/abs.hpp
+++ b/include/xmipp4/core/math/abs.hpp
@@ -2,14 +2,6 @@
 
 #pragma once
 
-/**
- * @file abs.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Provides abs function for various types.
- * @date 2024-04-15
- * 
- */
-
 #include "../platform/constexpr.hpp"
 
 #include <type_traits>

--- a/include/xmipp4/core/math/abs.hpp
+++ b/include/xmipp4/core/math/abs.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file abs.hpp

--- a/include/xmipp4/core/math/abs.inl
+++ b/include/xmipp4/core/math/abs.inl
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file abs.inl
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of abs.hpp
- * @date 2024-04-15
- * 
- */
-
 #include "abs.hpp"
 
 #include "../platform/builtin.h"

--- a/include/xmipp4/core/math/abs.inl
+++ b/include/xmipp4/core/math/abs.inl
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file abs.inl

--- a/include/xmipp4/core/math/arithmetic.hpp
+++ b/include/xmipp4/core/math/arithmetic.hpp
@@ -2,14 +2,6 @@
 
 #pragma once
 
-/**
- * @file arithmetic.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Provides various arithmetic functions.
- * @date 2024-04-15
- * 
- */
-
 #include "../platform/constexpr.hpp"
 
 #include <type_traits>

--- a/include/xmipp4/core/math/arithmetic.hpp
+++ b/include/xmipp4/core/math/arithmetic.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file arithmetic.hpp

--- a/include/xmipp4/core/math/arithmetic.inl
+++ b/include/xmipp4/core/math/arithmetic.inl
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file arithmetic.inl

--- a/include/xmipp4/core/math/arithmetic.inl
+++ b/include/xmipp4/core/math/arithmetic.inl
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file arithmetic.inl
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of arithmetic.hpp
- * @date 2024-04-15
- * 
- */
-
 #include "arithmetic.hpp"
 
 #include "../platform/builtin.h"

--- a/include/xmipp4/core/math/bessel.hpp
+++ b/include/xmipp4/core/math/bessel.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file bessel.hpp

--- a/include/xmipp4/core/math/bessel.hpp
+++ b/include/xmipp4/core/math/bessel.hpp
@@ -2,14 +2,6 @@
 
 #pragma once
 
-/**
- * @file bessel.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Provides multiple variants of bessel functions.
- * @date 2024-04-15
- * 
- */
-
 #include <type_traits>
 
 namespace xmipp4

--- a/include/xmipp4/core/math/bessel.inl
+++ b/include/xmipp4/core/math/bessel.inl
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file bessel.inl
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of bessel.hpp
- * @date 2024-04-15
- * 
- */
-
 #include "bessel.hpp"
 
 #include "abs.hpp"

--- a/include/xmipp4/core/math/bessel.inl
+++ b/include/xmipp4/core/math/bessel.inl
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file bessel.inl

--- a/include/xmipp4/core/math/bspline.hpp
+++ b/include/xmipp4/core/math/bspline.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file bspline.hpp

--- a/include/xmipp4/core/math/bspline.hpp
+++ b/include/xmipp4/core/math/bspline.hpp
@@ -2,14 +2,6 @@
 
 #pragma once
 
-/**
- * @file bspline.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Provides B-Spline functions.
- * @date 2024-10-24
- * 
- */
-
 #include "../platform/constexpr.hpp"
 
 #include <type_traits>

--- a/include/xmipp4/core/math/bspline.inl
+++ b/include/xmipp4/core/math/bspline.inl
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file bspline.inl

--- a/include/xmipp4/core/math/bspline.inl
+++ b/include/xmipp4/core/math/bspline.inl
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file bspline.inl
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of bspline.hpp
- * @date 2024-10-24
- * 
- */
-
 #include "bspline.hpp"
 
 #include "abs.hpp"

--- a/include/xmipp4/core/math/constants.hpp
+++ b/include/xmipp4/core/math/constants.hpp
@@ -2,14 +2,6 @@
 
 #pragma once
 
-/**
- * @file constants.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Definition of common mathematical constants.
- * @date 2024-04-15
- * 
- */
-
 #include "../platform/constexpr.hpp"
 
 #include <type_traits>

--- a/include/xmipp4/core/math/constants.hpp
+++ b/include/xmipp4/core/math/constants.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file constants.hpp

--- a/include/xmipp4/core/math/constants.inl
+++ b/include/xmipp4/core/math/constants.inl
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file constants.inl

--- a/include/xmipp4/core/math/constants.inl
+++ b/include/xmipp4/core/math/constants.inl
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file constants.inl
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of constants.hpp
- * @date 2024-04-15
- * 
- */
-
 #include "constants.hpp"
 
 namespace xmipp4

--- a/include/xmipp4/core/math/erf.hpp
+++ b/include/xmipp4/core/math/erf.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file erf.hpp

--- a/include/xmipp4/core/math/erf.hpp
+++ b/include/xmipp4/core/math/erf.hpp
@@ -2,14 +2,6 @@
 
 #pragma once
 
-/**
- * @file erf.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Provides the error function (erf).
- * @date 2024-04-15
- * 
- */
-
 #include <type_traits>
 
 namespace xmipp4

--- a/include/xmipp4/core/math/erf.inl
+++ b/include/xmipp4/core/math/erf.inl
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file erf.inl

--- a/include/xmipp4/core/math/erf.inl
+++ b/include/xmipp4/core/math/erf.inl
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file erf.inl
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of erf.hpp
- * @date 2024-04-15
- * 
- */
-
 #include "erf.hpp"
 
 #include "../platform/builtin.h"

--- a/include/xmipp4/core/math/exponential.hpp
+++ b/include/xmipp4/core/math/exponential.hpp
@@ -2,14 +2,6 @@
 
 #pragma once
 
-/**
- * @file exponential.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Provides multiple exponential and logarithmic functions.
- * @date 2024-04-15
- * 
- */
-
 #include <type_traits>
 
 namespace xmipp4

--- a/include/xmipp4/core/math/exponential.hpp
+++ b/include/xmipp4/core/math/exponential.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file exponential.hpp

--- a/include/xmipp4/core/math/exponential.inl
+++ b/include/xmipp4/core/math/exponential.inl
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file exponential.inl

--- a/include/xmipp4/core/math/exponential.inl
+++ b/include/xmipp4/core/math/exponential.inl
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file exponential.inl
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of exponential.hpp
- * @date 2024-04-15
- * 
- */
-
 #include "exponential.hpp"
 
 #include "power.hpp"

--- a/include/xmipp4/core/math/factorial.hpp
+++ b/include/xmipp4/core/math/factorial.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file factorial.hpp

--- a/include/xmipp4/core/math/factorial.hpp
+++ b/include/xmipp4/core/math/factorial.hpp
@@ -2,14 +2,6 @@
 
 #pragma once
 
-/**
- * @file factorial.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Provides factorial and gamma functions.
- * @date 2024-04-15
- * 
- */
-
 #include "../platform/constexpr.hpp"
 
 #include <type_traits>

--- a/include/xmipp4/core/math/factorial.inl
+++ b/include/xmipp4/core/math/factorial.inl
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file factorial.inl

--- a/include/xmipp4/core/math/factorial.inl
+++ b/include/xmipp4/core/math/factorial.inl
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file factorial.inl
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of factorial.hpp
- * @date 2024-04-15
- * 
- */
-
 #include "abs.hpp"
 
 #include "../platform/builtin.h"

--- a/include/xmipp4/core/math/hyperbolic.hpp
+++ b/include/xmipp4/core/math/hyperbolic.hpp
@@ -2,14 +2,6 @@
 
 #pragma once
 
-/**
- * @file hyperbolic.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Provides hyperbolic functions.
- * @date 2024-04-15
- * 
- */
-
 #include <type_traits>
 
 namespace xmipp4

--- a/include/xmipp4/core/math/hyperbolic.hpp
+++ b/include/xmipp4/core/math/hyperbolic.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file hyperbolic.hpp

--- a/include/xmipp4/core/math/hyperbolic.inl
+++ b/include/xmipp4/core/math/hyperbolic.inl
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file hyperbolic.inl

--- a/include/xmipp4/core/math/hyperbolic.inl
+++ b/include/xmipp4/core/math/hyperbolic.inl
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file hyperbolic.inl
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of hyperbolic.hpp
- * @date 2024-04-15
- * 
- */
-
 #include "hyperbolic.hpp"
 
 #include "../platform/builtin.h"

--- a/include/xmipp4/core/math/math.hpp
+++ b/include/xmipp4/core/math/math.hpp
@@ -2,14 +2,6 @@
 
 #pragma once
 
-/**
- * @file math.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Includes all math headers.
- * @date 2024-04-15
- * 
- */
-
 #include "abs.hpp"
 #include "arithmetic.hpp"
 #include "bessel.hpp"

--- a/include/xmipp4/core/math/math.hpp
+++ b/include/xmipp4/core/math/math.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file math.hpp

--- a/include/xmipp4/core/math/nearest_integer.hpp
+++ b/include/xmipp4/core/math/nearest_integer.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file nearest_integer.hpp

--- a/include/xmipp4/core/math/nearest_integer.hpp
+++ b/include/xmipp4/core/math/nearest_integer.hpp
@@ -2,14 +2,6 @@
 
 #pragma once
 
-/**
- * @file nearest_integer.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Provides nearest integer rounding functions.
- * @date 2024-04-15
- * 
- */
-
 #include <type_traits>
 
 namespace xmipp4

--- a/include/xmipp4/core/math/nearest_integer.inl
+++ b/include/xmipp4/core/math/nearest_integer.inl
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file nearest_integer.inl

--- a/include/xmipp4/core/math/nearest_integer.inl
+++ b/include/xmipp4/core/math/nearest_integer.inl
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file nearest_integer.inl
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of nearest_integer.hpp
- * @date 2024-04-15
- * 
- */
-
 #include "nearest_integer.hpp"
 
 #include "../platform/builtin.h"

--- a/include/xmipp4/core/math/power.hpp
+++ b/include/xmipp4/core/math/power.hpp
@@ -2,14 +2,6 @@
 
 #pragma once
 
-/**
- * @file power.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Provides arbitrary exponentiation functions.
- * @date 2024-04-15
- * 
- */
-
 #include "../platform/constexpr.hpp"
 
 #include <type_traits>

--- a/include/xmipp4/core/math/power.hpp
+++ b/include/xmipp4/core/math/power.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file power.hpp

--- a/include/xmipp4/core/math/power.inl
+++ b/include/xmipp4/core/math/power.inl
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file power.inl

--- a/include/xmipp4/core/math/power.inl
+++ b/include/xmipp4/core/math/power.inl
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file power.inl
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of power.hpp
- * @date 2024-04-15
- * 
- */
-
 #include "power.hpp"
 
 #include "abs.hpp"

--- a/include/xmipp4/core/math/trigonometric.hpp
+++ b/include/xmipp4/core/math/trigonometric.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file trigonometric.hpp

--- a/include/xmipp4/core/math/trigonometric.hpp
+++ b/include/xmipp4/core/math/trigonometric.hpp
@@ -2,14 +2,6 @@
 
 #pragma once
 
-/**
- * @file trigonometric.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Provides trigonometric functions.
- * @date 2024-04-15
- * 
- */
-
 #include <utility>
 #include <type_traits>
 

--- a/include/xmipp4/core/math/trigonometric.inl
+++ b/include/xmipp4/core/math/trigonometric.inl
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file trigonometric.inl
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of trigonometric.hpp
- * @date 2024-04-15
- * 
- */
-
 #include "trigonometric.hpp"
 
 #include "../platform/builtin.h"

--- a/include/xmipp4/core/math/trigonometric.inl
+++ b/include/xmipp4/core/math/trigonometric.inl
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file trigonometric.inl

--- a/include/xmipp4/core/memory/align.hpp
+++ b/include/xmipp4/core/memory/align.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file align.hpp

--- a/include/xmipp4/core/memory/align.hpp
+++ b/include/xmipp4/core/memory/align.hpp
@@ -2,14 +2,6 @@
 
 #pragma once
 
-/**
- * @file align.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Utility functions related to memory address manipulations
- * @date 2023-08-31
- * 
- */
-
 #include "../platform/attributes.hpp"
 #include "../platform/constexpr.hpp"
 

--- a/include/xmipp4/core/memory/align.inl
+++ b/include/xmipp4/core/memory/align.inl
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 #include "align.hpp"
 

--- a/include/xmipp4/core/memory/aligned_alloc.hpp
+++ b/include/xmipp4/core/memory/aligned_alloc.hpp
@@ -2,14 +2,6 @@
 
 #pragma once
 
-/**
- * @file aligned_alloc.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Allocate memory with alignment specifications.
- * @date 2024-12-02
- * 
- */
-
 #include "../platform/attributes.hpp"
 #include "../platform/dynamic_shared_object.h"
 

--- a/include/xmipp4/core/memory/aligned_alloc.hpp
+++ b/include/xmipp4/core/memory/aligned_alloc.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file aligned_alloc.hpp

--- a/include/xmipp4/core/memory/byte.hpp
+++ b/include/xmipp4/core/memory/byte.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file byte.hpp

--- a/include/xmipp4/core/memory/byte.hpp
+++ b/include/xmipp4/core/memory/byte.hpp
@@ -2,14 +2,6 @@
 
 #pragma once
 
-/**
- * @file byte.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Provides C++17 like byte type
- * @date 2023-08-12
- * 
- */
-
 #include "../platform/attributes.hpp"
 #include "../platform/constexpr.hpp"
 

--- a/include/xmipp4/core/memory/byte.inl
+++ b/include/xmipp4/core/memory/byte.inl
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file byte.inl

--- a/include/xmipp4/core/memory/byte.inl
+++ b/include/xmipp4/core/memory/byte.inl
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file byte.inl
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of byte.hpp
- * @date 2023-08-12
- * 
- */
-
 #include "byte.hpp"
 
 #include <array>

--- a/include/xmipp4/core/memory/byte_order.hpp
+++ b/include/xmipp4/core/memory/byte_order.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file byte_order.hpp

--- a/include/xmipp4/core/memory/byte_order.hpp
+++ b/include/xmipp4/core/memory/byte_order.hpp
@@ -2,14 +2,6 @@
 
 #pragma once
 
-/**
- * @file byte_order.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Definition of byte_order dependant words and conversion methods
- * @date 2023-08-12
- * 
- */
-
 #include "../platform/attributes.hpp"
 #include "../platform/constexpr.hpp"
 

--- a/include/xmipp4/core/memory/byte_order.inl
+++ b/include/xmipp4/core/memory/byte_order.inl
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file byte_order.inl
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of byte_order.hpp
- * @date 2023-08-12
- * 
- */
-
 #include "byte_order.hpp"
 
 #include "../platform/byte_order.h"

--- a/include/xmipp4/core/memory/byte_order.inl
+++ b/include/xmipp4/core/memory/byte_order.inl
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file byte_order.inl

--- a/include/xmipp4/core/memory/pimpl.hpp
+++ b/include/xmipp4/core/memory/pimpl.hpp
@@ -2,14 +2,6 @@
 
 #pragma once
 
-/**
- * @file pimpl.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Provides pimpl class
- * @date 2024-03-10
- * 
- */
-
 #include "../platform/constexpr.hpp"
 #include "../platform/attributes.hpp"
 

--- a/include/xmipp4/core/memory/pimpl.hpp
+++ b/include/xmipp4/core/memory/pimpl.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file pimpl.hpp

--- a/include/xmipp4/core/memory/pimpl.inl
+++ b/include/xmipp4/core/memory/pimpl.inl
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file pimpl.inl
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of pimpl.hpp
- * @date 2024-03-10
- * 
- */
-
 #include "pimpl.hpp"
 
 #include "propagate_allocator.hpp"

--- a/include/xmipp4/core/memory/pimpl.inl
+++ b/include/xmipp4/core/memory/pimpl.inl
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file pimpl.inl

--- a/include/xmipp4/core/memory/propagate_allocator.hpp
+++ b/include/xmipp4/core/memory/propagate_allocator.hpp
@@ -2,15 +2,6 @@
 
 #pragma once
 
-/**
- * @file propagate_allocator.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Provides functions that conditionally propagate allocator assignments
- * based on std::allocator_traits
- * @date 2024-03-12
- * 
- */
-
 namespace xmipp4 
 {
 namespace memory

--- a/include/xmipp4/core/memory/propagate_allocator.hpp
+++ b/include/xmipp4/core/memory/propagate_allocator.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file propagate_allocator.hpp

--- a/include/xmipp4/core/memory/propagate_allocator.inl
+++ b/include/xmipp4/core/memory/propagate_allocator.inl
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file propagate_allocator.inl

--- a/include/xmipp4/core/memory/propagate_allocator.inl
+++ b/include/xmipp4/core/memory/propagate_allocator.inl
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file propagate_allocator.inl
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of propagate_allocator.hpp
- * @date 2024-03-12
- * 
- */
-
 #include "propagate_allocator.hpp"
 
 #include <memory>

--- a/include/xmipp4/core/multidimensional/axis_descriptor.hpp
+++ b/include/xmipp4/core/multidimensional/axis_descriptor.hpp
@@ -2,14 +2,6 @@
 
 #pragma once
 
-/**
- * @file axis_descriptor.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Defines axis_descriptor class
- * @date 2023-08-13
- * 
- */
-
 #include "../slice.hpp"
 #include "../platform/constexpr.hpp"
 #include "../platform/attributes.hpp"

--- a/include/xmipp4/core/multidimensional/axis_descriptor.hpp
+++ b/include/xmipp4/core/multidimensional/axis_descriptor.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file axis_descriptor.hpp

--- a/include/xmipp4/core/multidimensional/axis_descriptor.inl
+++ b/include/xmipp4/core/multidimensional/axis_descriptor.inl
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file axis_descriptor.inl
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of axis_descriptor
- * @date 2023-08-13
- * 
- */
-
 #include "axis_descriptor.hpp"
 
 #include "../index.hpp"

--- a/include/xmipp4/core/multidimensional/axis_descriptor.inl
+++ b/include/xmipp4/core/multidimensional/axis_descriptor.inl
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file axis_descriptor.inl

--- a/include/xmipp4/core/multidimensional/layout_flags.hpp
+++ b/include/xmipp4/core/multidimensional/layout_flags.hpp
@@ -2,14 +2,6 @@
 
 #pragma once
 
-/**
- * @file layout_flags.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Declares layout_flags flagset
- * @date 2024-05-01
- * 
- */
-
 #include "../binary/bit.hpp"
 #include "../binary/flagset.hpp"
 #include "../platform/constexpr.hpp"

--- a/include/xmipp4/core/multidimensional/layout_flags.hpp
+++ b/include/xmipp4/core/multidimensional/layout_flags.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file layout_flags.hpp

--- a/include/xmipp4/core/multidimensional/layout_flags.inl
+++ b/include/xmipp4/core/multidimensional/layout_flags.inl
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file layout_flags.inl
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of layout_flags.hpp
- * @date 2024-05-01
- * 
- */
-
 #include "layout_flags.hpp"
 
 #include <unordered_map>

--- a/include/xmipp4/core/multidimensional/layout_flags.inl
+++ b/include/xmipp4/core/multidimensional/layout_flags.inl
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file layout_flags.inl

--- a/include/xmipp4/core/multidimensional/strided_layout_utils.hpp
+++ b/include/xmipp4/core/multidimensional/strided_layout_utils.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file strided_layout_utils.hpp

--- a/include/xmipp4/core/multidimensional/strided_layout_utils.hpp
+++ b/include/xmipp4/core/multidimensional/strided_layout_utils.hpp
@@ -2,15 +2,6 @@
 
 #pragma once
 
-/**
- * @file strided_layout_utils.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Declaration of utility functions for handling sequences 
- * of axis_descriptor
- * @date 2023-10-16
- * 
- */
-
 #include "axis_descriptor.hpp"
 #include "layout_flags.hpp"
 #include "subscript_sequence.hpp"

--- a/include/xmipp4/core/multidimensional/strided_layout_utils.inl
+++ b/include/xmipp4/core/multidimensional/strided_layout_utils.inl
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file strided_layout_utils.inl

--- a/include/xmipp4/core/multidimensional/strided_layout_utils.inl
+++ b/include/xmipp4/core/multidimensional/strided_layout_utils.inl
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file strided_layout_utils.inl
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of strided_layout_utils.hpp
- * @date 2023-08-16
- * 
- */
-
 #include "strided_layout_utils.hpp"
 
 #include <algorithm>

--- a/include/xmipp4/core/multidimensional/subscript_sequence.hpp
+++ b/include/xmipp4/core/multidimensional/subscript_sequence.hpp
@@ -2,14 +2,6 @@
 
 #pragma once
 
-/**
- * @file subscript_sequence.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Provides utilities for manipulating subscript sequences
- * @date 2024-04-03
- * 
- */
-
 #include "../platform/attributes.hpp"
 #include "../platform/constexpr.hpp"
 

--- a/include/xmipp4/core/multidimensional/subscript_sequence.hpp
+++ b/include/xmipp4/core/multidimensional/subscript_sequence.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file subscript_sequence.hpp

--- a/include/xmipp4/core/multidimensional/subscript_sequence.inl
+++ b/include/xmipp4/core/multidimensional/subscript_sequence.inl
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file subscript_sequence.inl

--- a/include/xmipp4/core/multidimensional/subscript_sequence.inl
+++ b/include/xmipp4/core/multidimensional/subscript_sequence.inl
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file subscript_sequence.inl
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of subscript_sequence.hpp
- * @date 2024-04-03
- * 
- */
-
 #include "subscript_sequence.hpp"
 
 #include <utility>

--- a/include/xmipp4/core/platform/assert.hpp
+++ b/include/xmipp4/core/platform/assert.hpp
@@ -2,14 +2,6 @@
 
 #pragma once
 
-/**
- * @file assert.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Custom declaration of assert
- * @date 2023-08-08
- * 
- */
-
 #include <cassert>
 
 /**

--- a/include/xmipp4/core/platform/assert.hpp
+++ b/include/xmipp4/core/platform/assert.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file assert.hpp

--- a/include/xmipp4/core/platform/attributes.hpp
+++ b/include/xmipp4/core/platform/attributes.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file attributes.hpp

--- a/include/xmipp4/core/platform/builtin.h
+++ b/include/xmipp4/core/platform/builtin.h
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file builtin.h

--- a/include/xmipp4/core/platform/builtin.h
+++ b/include/xmipp4/core/platform/builtin.h
@@ -3,14 +3,6 @@
 #pragma once
 
 /**
- * @file builtin.h
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Macro definitions to check compiler builtin functions
- * @date 2023-08-08
- * 
- */
-
-/**
  * @brief Declaration name of a builtin function
  * 
  */

--- a/include/xmipp4/core/platform/byte_order.h
+++ b/include/xmipp4/core/platform/byte_order.h
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file byte_order.h

--- a/include/xmipp4/core/platform/byte_order.h
+++ b/include/xmipp4/core/platform/byte_order.h
@@ -2,13 +2,6 @@
 
 #pragma once
 
-/**
- * @file byte_order.h
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Macro definitions for determining byte ordering (endianess)
- * @date 2023-08-12
- */
-
 #include "operating_system.h"
 
 /**

--- a/include/xmipp4/core/platform/c_attributes.h
+++ b/include/xmipp4/core/platform/c_attributes.h
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file gcc_attributes.hpp

--- a/include/xmipp4/core/platform/c_attributes.h
+++ b/include/xmipp4/core/platform/c_attributes.h
@@ -3,19 +3,6 @@
 #pragma once
 
 /**
- * @file gcc_attributes.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Macro definitions for GCC attributes.
- * @date 2023-08-08
- * 
- * This file provides definitions for accessing GCC
- * attributes, if available
- * 
- */
-
-
-
-/**
  * @brief GCC attribute declaration
  * @see https://gcc.gnu.org/onlinedocs/gcc/Function-Attributes.html
  * 

--- a/include/xmipp4/core/platform/c_features.h
+++ b/include/xmipp4/core/platform/c_features.h
@@ -3,20 +3,9 @@
 #pragma once
 
 /**
- * @file c_features.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Macro definitions for feature testing C compiler and 
- * @date 2024-03-06
- * @see https://en.cppreference.com/w/cpp/feature_test
- * 
- * This file provides definitions for testing support of C features 
- * available for the compiler
- * 
- */
-
-/**
  * @def XMIPP4_HAS_C_FEATURE
  * @brief Check if a feature is supported by the compiler
+ * @see https://en.cppreference.com/w/cpp/feature_test
  * 
  */
 #if defined(__has_feature)

--- a/include/xmipp4/core/platform/c_features.h
+++ b/include/xmipp4/core/platform/c_features.h
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file c_features.hpp

--- a/include/xmipp4/core/platform/compiler.h
+++ b/include/xmipp4/core/platform/compiler.h
@@ -3,14 +3,6 @@
 #pragma once
 
 /**
- * @file compiler.h
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Provides macros for detecting the compiler
- * @date 2025-07-12
- * 
- */
-
-/**
  * @def XMIPP4_CLANG
  * @brief Defined when building with Clang
  * 

--- a/include/xmipp4/core/platform/compiler.h
+++ b/include/xmipp4/core/platform/compiler.h
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file compiler.h

--- a/include/xmipp4/core/platform/constexpr.hpp
+++ b/include/xmipp4/core/platform/constexpr.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file constexpr.hpp

--- a/include/xmipp4/core/platform/constexpr.hpp
+++ b/include/xmipp4/core/platform/constexpr.hpp
@@ -2,17 +2,6 @@
 
 #pragma once
 
-/**
- * @file constexpr.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Macro definitions for version dependant constexpr
- * @date 2023-08-08
- * 
- * This file provides definitions for using constexpr when
- * supported
- * 
- */
-
 #include "cpp_features.hpp"
 
 #if XMIPP4_HAS_CONSTEXPR || defined(XMIPP4_DOC_BUILD)

--- a/include/xmipp4/core/platform/cpp_attributes.hpp
+++ b/include/xmipp4/core/platform/cpp_attributes.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file cpp_attributes.hpp

--- a/include/xmipp4/core/platform/cpp_attributes.hpp
+++ b/include/xmipp4/core/platform/cpp_attributes.hpp
@@ -3,18 +3,6 @@
 #pragma once
 
 /**
- * @file cpp_attributes.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Macro definitions for C++ attributes.
- * @date 2023-08-08
- * 
- * This file provides definitions for accessing C++
- * attributes, if available
- * 
- */
-
-
-/**
  * @brief C++ attribute declaration
  * @see https://en.cppreference.com/w/cpp/language/attributes
  * 

--- a/include/xmipp4/core/platform/cpp_execution.hpp
+++ b/include/xmipp4/core/platform/cpp_execution.hpp
@@ -2,14 +2,6 @@
 
 #pragma once
 
-/**
- * @file cpp_execution.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Macro definitions for using C++ algorithm parallelization
- * @date 2023-11-14
- * 
- */
-
 #include "cpp_features.hpp"
 
 #if XMIPP4_HAS_LIB_EXECUTION

--- a/include/xmipp4/core/platform/cpp_execution.hpp
+++ b/include/xmipp4/core/platform/cpp_execution.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file cpp_execution.hpp

--- a/include/xmipp4/core/platform/cpp_features.hpp
+++ b/include/xmipp4/core/platform/cpp_features.hpp
@@ -2,20 +2,6 @@
 
 #pragma once
 
-/**
- * @file cpp_features.hpp
- * @author Mikel Iceta Tena (miceta@cnb.csic.es)
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Macro definitions for feature testing C++ compiler and 
- * standard library
- * @date 2024-02-16
- * @see https://en.cppreference.com/w/cpp/feature_test
- * 
- * This file provides definitions for testing support of C++ features 
- * available for the compiler and standard library.
- * 
- */
-
 #include "c_features.h"
 #include "cpp_version.hpp"
 

--- a/include/xmipp4/core/platform/cpp_features.hpp
+++ b/include/xmipp4/core/platform/cpp_features.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file cpp_features.hpp

--- a/include/xmipp4/core/platform/cpp_version.hpp
+++ b/include/xmipp4/core/platform/cpp_version.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file cpp_version.hpp

--- a/include/xmipp4/core/platform/cpp_version.hpp
+++ b/include/xmipp4/core/platform/cpp_version.hpp
@@ -3,17 +3,6 @@
 #pragma once
 
 /**
- * @file cpp_version.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Macro definitions for detecting C++ version
- * @date 2023-08-08
- * 
- * This file provides definitions for determining 
- * the C++ version support
- * 
- */
-
-/**
  * @def XMIPP4_CPLUSPLUS
  * @brief C++ standard version
  * 

--- a/include/xmipp4/core/platform/dynamic_shared_object.h
+++ b/include/xmipp4/core/platform/dynamic_shared_object.h
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file dynamic_shared_object.h

--- a/include/xmipp4/core/platform/dynamic_shared_object.h
+++ b/include/xmipp4/core/platform/dynamic_shared_object.h
@@ -2,15 +2,6 @@
 
 #pragma once
 
-/**
- * @file dynamic_shared_object.h
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Provides API definition macros for selectively exporting
- * to the final binary file.
- * @date 2023-08-08
- * 
- */
-
 #include "c_attributes.h"
 #include "operating_system.h"
 

--- a/include/xmipp4/core/platform/openmp.h
+++ b/include/xmipp4/core/platform/openmp.h
@@ -2,15 +2,6 @@
 
 #pragma once
 
-/**
- * @file openmp.h
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Provides a cross-platform macro for accessing OpenMP functionality
- * when supported
- * @date 2024-10-25
- * 
- */
-
 #include "pragma.h"
 
 /**

--- a/include/xmipp4/core/platform/openmp.h
+++ b/include/xmipp4/core/platform/openmp.h
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file openmp.h

--- a/include/xmipp4/core/platform/operating_system.h
+++ b/include/xmipp4/core/platform/operating_system.h
@@ -3,14 +3,6 @@
 #pragma once
 
 /**
- * @file operating_system.h
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Provides macros for detecting the target OS
- * @date 2023-08-08
- * 
- */
-
-/**
  * @def XMIPP4_WINDOWS
  * @brief Defined if the target is Windows (32bit or 64bit)
  * 

--- a/include/xmipp4/core/platform/operating_system.h
+++ b/include/xmipp4/core/platform/operating_system.h
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file operating_system.h

--- a/include/xmipp4/core/platform/pragma.h
+++ b/include/xmipp4/core/platform/pragma.h
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file pragma.h

--- a/include/xmipp4/core/platform/pragma.h
+++ b/include/xmipp4/core/platform/pragma.h
@@ -2,14 +2,6 @@
 
 #pragma once
 
-/**
- * @file pragma.h
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Provides a cross-platform macro for compiler pragma directives.
- * @date 2024-10-25
- * 
- */
-
 #include "stringfy.h"
 
 /**

--- a/include/xmipp4/core/platform/stringfy.h
+++ b/include/xmipp4/core/platform/stringfy.h
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file stringfy.h

--- a/include/xmipp4/core/platform/stringfy.h
+++ b/include/xmipp4/core/platform/stringfy.h
@@ -3,14 +3,6 @@
 #pragma once
 
 /**
- * @file stringfy.h
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Provides macro for stringfying literals.
- * @date 2024-10-25
- * 
- */
-
-/**
  * @brief Stringfy the literal x
  * 
  */

--- a/include/xmipp4/core/plugin.hpp
+++ b/include/xmipp4/core/plugin.hpp
@@ -2,14 +2,6 @@
 
 #pragma once
 
-/**
- * @file plugin.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Defines plugin class
- * @date 2024-03-11
- * 
- */
-
 #include "version.hpp"
 #include "platform/dynamic_shared_object.h"
 

--- a/include/xmipp4/core/plugin.hpp
+++ b/include/xmipp4/core/plugin.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file plugin.hpp

--- a/include/xmipp4/core/plugin_manager.hpp
+++ b/include/xmipp4/core/plugin_manager.hpp
@@ -2,14 +2,6 @@
 
 #pragma once
 
-/**
- * @file plugin_manager.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Defines plugin_manager class
- * @date 2024-03-11
- * 
- */
-
 #include "memory/pimpl.hpp"
 #include "platform/dynamic_shared_object.h"
 

--- a/include/xmipp4/core/plugin_manager.hpp
+++ b/include/xmipp4/core/plugin_manager.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file plugin_manager.hpp

--- a/include/xmipp4/core/reduction_operation.hpp
+++ b/include/xmipp4/core/reduction_operation.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file reduction_operation.hpp

--- a/include/xmipp4/core/reduction_operation.hpp
+++ b/include/xmipp4/core/reduction_operation.hpp
@@ -2,14 +2,6 @@
 
 #pragma once
 
-/**
- * @file reduction_operation.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Defines the reduction_operation enum.
- * @date 2024-10-24
- * 
- */
-
 #include "platform/constexpr.hpp"
 
 #include <cstddef>

--- a/include/xmipp4/core/reduction_operation.inl
+++ b/include/xmipp4/core/reduction_operation.inl
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file reduction_operation.inl

--- a/include/xmipp4/core/reduction_operation.inl
+++ b/include/xmipp4/core/reduction_operation.inl
@@ -2,14 +2,6 @@
 
 #pragma once
 
-/**
- * @file reduction_operation.inl
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of reduction_operation.inl
- * @date 2024-10-24
- * 
- */
-
 #include "reduction_operation.hpp"
 
 #include <unordered_map>

--- a/include/xmipp4/core/slice.hpp
+++ b/include/xmipp4/core/slice.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file slice.hpp

--- a/include/xmipp4/core/slice.hpp
+++ b/include/xmipp4/core/slice.hpp
@@ -2,14 +2,6 @@
 
 #pragma once
 
-/**
- * @file slice.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Definition of slice class and helper tags
- * @date 2023-08-13
- * 
- */
-
 #include "platform/constexpr.hpp"
 #include "platform/attributes.hpp"
 

--- a/include/xmipp4/core/slice.inl
+++ b/include/xmipp4/core/slice.inl
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file slice.inl

--- a/include/xmipp4/core/slice.inl
+++ b/include/xmipp4/core/slice.inl
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file slice.inl
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of slice.hpp
- * @date 2023-08-13
- * 
- */
-
 #include "slice.hpp"
 
 #include <sstream>

--- a/include/xmipp4/core/span.hpp
+++ b/include/xmipp4/core/span.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file span.hpp

--- a/include/xmipp4/core/span.hpp
+++ b/include/xmipp4/core/span.hpp
@@ -1,17 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
+// Implementation based on: https://github.com/tcbrindle/span
 
 #pragma once
-
-/**
- * @file span.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Provides span enumeration and utility functions
- * @date 2024-10-24
- * 
- * Implementation based on:
- * https://github.com/tcbrindle/span
- * 
- */
 
 #include "memory/byte.hpp"
 #include "platform/attributes.hpp"

--- a/include/xmipp4/core/span.inl
+++ b/include/xmipp4/core/span.inl
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file span.inl
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of span.hpp
- * @date 2024-10-24
- * 
- */
-
 #include "span.hpp"
 
 #include "platform/assert.hpp"

--- a/include/xmipp4/core/span.inl
+++ b/include/xmipp4/core/span.inl
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file span.inl

--- a/include/xmipp4/core/system/dynamic_library.hpp
+++ b/include/xmipp4/core/system/dynamic_library.hpp
@@ -1,26 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * Authors:     Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file dynamic_library.hpp

--- a/include/xmipp4/core/system/dynamic_library.hpp
+++ b/include/xmipp4/core/system/dynamic_library.hpp
@@ -2,13 +2,6 @@
 
 #pragma once
 
-/**
- * @file dynamic_library.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Definition of dynamic_library class
- * @date 2023-07-09
- */
-
 #include "../version.hpp"
 #include "../platform/dynamic_shared_object.h"
 

--- a/include/xmipp4/core/system/host.hpp
+++ b/include/xmipp4/core/system/host.hpp
@@ -2,14 +2,6 @@
 
 #pragma once
 
-/**
- * @file host.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Utilities to query the host
- * @date 2024-10-29
- * 
- */
-
 #include <string>
 
 namespace xmipp4 

--- a/include/xmipp4/core/system/host.hpp
+++ b/include/xmipp4/core/system/host.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file host.hpp

--- a/include/xmipp4/core/system/memory_mapped_file.hpp
+++ b/include/xmipp4/core/system/memory_mapped_file.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 #include "../access_flags.hpp"
 #include "../platform/dynamic_shared_object.h"

--- a/include/xmipp4/core/version.hpp
+++ b/include/xmipp4/core/version.hpp
@@ -2,14 +2,6 @@
 
 #pragma once
 
-/**
- * @file version.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Definition of the version class
- * @date 2023-08-12
- * 
- */
-
 #include "platform/constexpr.hpp"
 #include "binary/bit.hpp"
 

--- a/include/xmipp4/core/version.hpp
+++ b/include/xmipp4/core/version.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file version.hpp

--- a/include/xmipp4/core/version.inl
+++ b/include/xmipp4/core/version.inl
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file version.inl
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of version.hpp
- * @date 2023-08-12
- * 
- */
-
 #include "version.hpp"
 
 namespace xmipp4 

--- a/include/xmipp4/core/version.inl
+++ b/include/xmipp4/core/version.inl
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file version.inl

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,23 +1,3 @@
-#***************************************************************************
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-# 02111-1307  USA
-#
-#  All comments concerning this program package may be sent to the
-#  e-mail address 'xmipp@cnb.csic.es'
-# ***************************************************************************
-
 [build-system]
 requires = [
     "scikit-build-core==0.10"

--- a/src/communication/communicator_manager.cpp
+++ b/src/communication/communicator_manager.cpp
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file communicator_manager.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of communicator_manager.hpp
- * @date 2024-10-25
- * 
- */
-
 #include <xmipp4/core/communication/communicator_manager.hpp>
 
 #include <xmipp4/core/exceptions/ambiguous_backend_error.hpp>

--- a/src/communication/communicator_manager.cpp
+++ b/src/communication/communicator_manager.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file communicator_manager.cpp

--- a/src/communication/dummy/dummy_communicator.cpp
+++ b/src/communication/dummy/dummy_communicator.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file dummy_communicator.cpp

--- a/src/communication/dummy/dummy_communicator.cpp
+++ b/src/communication/dummy/dummy_communicator.cpp
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file dummy_communicator.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of dummy_communicator.hpp
- * @date 2024-11-20
- * 
- */
-
 #include <xmipp4/core/communication/dummy/dummy_communicator.hpp>
 
 #include <stdexcept>

--- a/src/communication/dummy/dummy_communicator_backend.cpp
+++ b/src/communication/dummy/dummy_communicator_backend.cpp
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file dummy_communicator_backend.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of dummy_communicator_backend.hpp
- * @date 2024-10-26
- * 
- */
-
 #include <xmipp4/core/communication/dummy/dummy_communicator_backend.hpp>
 
 #include <xmipp4/core/communication/dummy/dummy_communicator.hpp>

--- a/src/communication/dummy/dummy_communicator_backend.cpp
+++ b/src/communication/dummy/dummy_communicator_backend.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file dummy_communicator_backend.cpp

--- a/src/compute/checks.cpp
+++ b/src/compute/checks.cpp
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file checks.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of checks.hpp
- * @date 2024-11-12
- * 
- */
-
 #include <xmipp4/core/compute/checks.hpp>
 
 #include <stdexcept>

--- a/src/compute/checks.cpp
+++ b/src/compute/checks.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file checks.cpp

--- a/src/compute/cpu/cpu_device.cpp
+++ b/src/compute/cpu/cpu_device.cpp
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file cpu_device.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of cpu_device.hpp
- * @date 2024-10-29
- * 
- */
-
 #include <xmipp4/core/compute/cpu/cpu_device.hpp>
 
 #include <xmipp4/core/compute/cpu/cpu_device_queue.hpp>

--- a/src/compute/cpu/cpu_device.cpp
+++ b/src/compute/cpu/cpu_device.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file cpu_device.cpp

--- a/src/compute/cpu/cpu_device_backend.cpp
+++ b/src/compute/cpu/cpu_device_backend.cpp
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file cpu_device_backend.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of cpu_device_backend.hpp
- * @date 2024-10-29
- * 
- */
-
 #include <xmipp4/core/compute/cpu/cpu_device_backend.hpp>
 
 #include <xmipp4/core/compute/cpu/cpu_device.hpp>

--- a/src/compute/cpu/cpu_device_backend.cpp
+++ b/src/compute/cpu/cpu_device_backend.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file cpu_device_backend.cpp

--- a/src/compute/cpu/cpu_device_queue.cpp
+++ b/src/compute/cpu/cpu_device_queue.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file cpu_device_queue.cpp

--- a/src/compute/cpu/cpu_device_queue.cpp
+++ b/src/compute/cpu/cpu_device_queue.cpp
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file cpu_device_queue.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of cpu_device_queue.hpp
- * @date 2024-10-29
- * 
- */
-
 #include <xmipp4/core/compute/cpu/cpu_device_queue.hpp>
 
 namespace xmipp4

--- a/src/compute/cpu/cpu_device_queue_pool.cpp
+++ b/src/compute/cpu/cpu_device_queue_pool.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file cpu_device_queue_pool.cpp

--- a/src/compute/cpu/cpu_device_queue_pool.cpp
+++ b/src/compute/cpu/cpu_device_queue_pool.cpp
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file cpu_device_queue_pool.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of cpu_device_queue_pool.hpp
- * @date 2024-11-27
- * 
- */
-
 #include <xmipp4/core/compute/cpu/cpu_device_queue_pool.hpp>
 
 #include <stdexcept>

--- a/src/compute/cpu/cpu_event.cpp
+++ b/src/compute/cpu/cpu_event.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file cpu_event.cpp

--- a/src/compute/cpu/cpu_event.cpp
+++ b/src/compute/cpu/cpu_event.cpp
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file cpu_event.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of cpu_event.hpp
- * @date 2024-11-13
- * 
- */
-
 #include <xmipp4/core/compute/cpu/cpu_event.hpp>
 
 

--- a/src/compute/cpu/cpu_transfer.cpp
+++ b/src/compute/cpu/cpu_transfer.cpp
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file cpu_transfer.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of cpu_transfer.hpp
- * @date 2024-11-06
- * 
- */
-
 #include <xmipp4/core/compute/cpu/cpu_transfer.hpp>
 
 #include <xmipp4/core/compute/cpu/cpu_unified_buffer.hpp>

--- a/src/compute/cpu/cpu_transfer.cpp
+++ b/src/compute/cpu/cpu_transfer.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file cpu_transfer.cpp

--- a/src/compute/cpu/cpu_unified_buffer.cpp
+++ b/src/compute/cpu/cpu_unified_buffer.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file cpu_unified_buffer.cpp

--- a/src/compute/cpu/cpu_unified_buffer.cpp
+++ b/src/compute/cpu/cpu_unified_buffer.cpp
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file cpu_unified_buffer.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of default_cpu_unified_buffer.hpp
- * @date 2024-11-26
- * 
- */
-
 #include <xmipp4/core/compute/cpu/cpu_unified_buffer.hpp>
 
 namespace xmipp4

--- a/src/compute/cpu/cpu_unified_memory_allocator.cpp
+++ b/src/compute/cpu/cpu_unified_memory_allocator.cpp
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file cpu_unified_memory_allocator.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of cpu_unified_memory_allocator.hpp
- * @date 2024-11-06
- * 
- */
-
 #include <xmipp4/core/compute/cpu/cpu_unified_memory_allocator.hpp>
 
 #include "default_cpu_unified_buffer.hpp"

--- a/src/compute/cpu/cpu_unified_memory_allocator.cpp
+++ b/src/compute/cpu/cpu_unified_memory_allocator.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file cpu_unified_memory_allocator.cpp

--- a/src/compute/cpu/default_cpu_unified_buffer.cpp
+++ b/src/compute/cpu/default_cpu_unified_buffer.cpp
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file default_cpu_unified_buffer.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of default_cpu_unified_buffer.hpp
- * @date 2024-10-29
- * 
- */
-
 #include "default_cpu_unified_buffer.hpp"
 
 #include <xmipp4/core/memory/aligned_alloc.hpp>

--- a/src/compute/cpu/default_cpu_unified_buffer.cpp
+++ b/src/compute/cpu/default_cpu_unified_buffer.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file default_cpu_unified_buffer.cpp

--- a/src/compute/cpu/default_cpu_unified_buffer.hpp
+++ b/src/compute/cpu/default_cpu_unified_buffer.hpp
@@ -2,14 +2,6 @@
 
 #pragma once
 
-/**
- * @file default_cpu_unified_buffer.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Defines the compute::default_cpu_unified_buffer interface
- * @date 2024-10-29
- * 
- */
-
 #include <xmipp4/core/compute/cpu/cpu_unified_buffer.hpp>
 
 namespace xmipp4 

--- a/src/compute/cpu/default_cpu_unified_buffer.hpp
+++ b/src/compute/cpu/default_cpu_unified_buffer.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file default_cpu_unified_buffer.hpp

--- a/src/compute/device_buffer.cpp
+++ b/src/compute/device_buffer.cpp
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file host_buffer.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of host_buffer.hpp
- * @date 2024-12-08
- * 
- */
-
 #include <xmipp4/core/compute/device_buffer.hpp>
 
 namespace xmipp4

--- a/src/compute/device_buffer.cpp
+++ b/src/compute/device_buffer.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file host_buffer.cpp

--- a/src/compute/device_manager.cpp
+++ b/src/compute/device_manager.cpp
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file device_manager.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of device_manager.hpp
- * @date 2024-10-23
- * 
- */
-
 #include <xmipp4/core/compute/device_manager.hpp>
 
 #include <xmipp4/core/compute/cpu/cpu_device_backend.hpp>

--- a/src/compute/device_manager.cpp
+++ b/src/compute/device_manager.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file device_manager.cpp

--- a/src/compute/host_buffer.cpp
+++ b/src/compute/host_buffer.cpp
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file host_buffer.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of host_buffer.hpp
- * @date 2024-11-09
- * 
- */
-
 #include <xmipp4/core/compute/host_buffer.hpp>
 
 #include <xmipp4/core/compute/checks.hpp>

--- a/src/compute/host_buffer.cpp
+++ b/src/compute/host_buffer.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file host_buffer.cpp

--- a/src/core_version.cpp
+++ b/src/core_version.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file core_version.cpp

--- a/src/core_version.cpp
+++ b/src/core_version.cpp
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file core_version.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of core_version.hpp
- * @date 2024-03-03
- * 
- */
-
 #include <xmipp4/core/core_version.hpp>
 
 namespace xmipp4

--- a/src/interface_catalog.cpp
+++ b/src/interface_catalog.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file interface_catalog.cpp

--- a/src/interface_catalog.cpp
+++ b/src/interface_catalog.cpp
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file interface_catalog.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of plugin.hpp
- * @date 2024-03-11
- * 
- */
-
 #include <xmipp4/core/interface_catalog.hpp>
 
 #include "plugin_loader.hpp"

--- a/src/memory/aligned_alloc.cpp
+++ b/src/memory/aligned_alloc.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file aligned_alloc.cpp

--- a/src/memory/aligned_alloc.cpp
+++ b/src/memory/aligned_alloc.cpp
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file aligned_alloc.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of aligned_alloc.hpp
- * @date 2024-12-02
- * 
- */
-
 #include <xmipp4/core/memory/aligned_alloc.hpp>
 
 #include <xmipp4/core/platform/operating_system.h>

--- a/src/plugin_loader.cpp
+++ b/src/plugin_loader.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file plugin_loader.cpp

--- a/src/plugin_loader.cpp
+++ b/src/plugin_loader.cpp
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file plugin_loader.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of plugin_loader.hpp
- * @date 2024-03-11
- * 
- */
-
 #include "plugin_loader.hpp"
 
 #include <xmipp4/core/exceptions/plugin_load_error.hpp>

--- a/src/plugin_loader.hpp
+++ b/src/plugin_loader.hpp
@@ -2,14 +2,6 @@
 
 #pragma once
 
-/**
- * @file plugin_loader.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Defines plugin_loader class
- * @date 2024-03-11
- * 
- */
-
 #include <xmipp4/core/system/dynamic_library.hpp>
 
 namespace xmipp4

--- a/src/plugin_loader.hpp
+++ b/src/plugin_loader.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file plugin_loader.hpp

--- a/src/plugin_manager.cpp
+++ b/src/plugin_manager.cpp
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file plugin_manager.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of plugin.hpp
- * @date 2024-03-11
- * 
- */
-
 #include <xmipp4/core/plugin_manager.hpp>
 
 #include "plugin_loader.hpp"

--- a/src/plugin_manager.cpp
+++ b/src/plugin_manager.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file plugin_manager.cpp

--- a/src/system/dynamic_library.cpp
+++ b/src/system/dynamic_library.cpp
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file dynamic_library.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of dynamic_library.hpp
- * @date 2023-08-13
- * 
- */
-
 #include <xmipp4/core/system/dynamic_library.hpp>
 
 #include "dynamic_library_handle.hpp"

--- a/src/system/dynamic_library.cpp
+++ b/src/system/dynamic_library.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file dynamic_library.cpp

--- a/src/system/dynamic_library_handle.hpp
+++ b/src/system/dynamic_library_handle.hpp
@@ -2,14 +2,6 @@
 
 #pragma once
 
-/**
- * @file dynamic_library_handle.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Platform independent functions for loading, unloading and querying
- * dynamic libraries
- * @date 2023-08-13
- * 
- */
 
 #include <xmipp4/core/platform/operating_system.h>
 

--- a/src/system/dynamic_library_handle.hpp
+++ b/src/system/dynamic_library_handle.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file dynamic_library_handle.hpp

--- a/src/system/dynamic_library_handle_posix.inl
+++ b/src/system/dynamic_library_handle_posix.inl
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file dynamic_library_handle_posix.inl
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief POSIX implementation of dynamic_library_handle.hpp
- * @date 2023-08-13
- * 
- */
-
 #include "dynamic_library_handle.hpp"
 
 #include <xmipp4/core/platform/constexpr.hpp>

--- a/src/system/dynamic_library_handle_posix.inl
+++ b/src/system/dynamic_library_handle_posix.inl
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file dynamic_library_handle_posix.inl

--- a/src/system/dynamic_library_handle_windows.inl
+++ b/src/system/dynamic_library_handle_windows.inl
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file dynamic_library_handle_windows.inl

--- a/src/system/dynamic_library_handle_windows.inl
+++ b/src/system/dynamic_library_handle_windows.inl
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file dynamic_library_handle_windows.inl
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Windows implementation of dynamic_library_handle.hpp
- * @date 2023-08-13
- * 
- */
-
 #include "dynamic_library_handle.hpp"
 
 #include <windows.h>

--- a/src/system/host.cpp
+++ b/src/system/host.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file host.cpp

--- a/src/system/host.cpp
+++ b/src/system/host.cpp
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file host.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of host.hpp
- * @date 2024-10-29
- * 
- */
-
 #include <xmipp4/core/system/host.hpp>
 #include <xmipp4/core/platform/operating_system.h>
 

--- a/src/system/memory_mapped_file.cpp
+++ b/src/system/memory_mapped_file.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file memory_mapped_file.cpp

--- a/src/system/memory_mapped_file.cpp
+++ b/src/system/memory_mapped_file.cpp
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file memory_mapped_file.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Implementation of memory_mapped_file.hpp
- * @date 2023-08-13
- * 
- */
-
 #include <xmipp4/core/system/memory_mapped_file.hpp>
 
 #include "memory_mapped_file_handle.hpp"

--- a/src/system/memory_mapped_file_handle.hpp
+++ b/src/system/memory_mapped_file_handle.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 #include <xmipp4/core/access_flags.hpp>
 #include <xmipp4/core/platform/operating_system.h>

--- a/src/system/memory_mapped_file_handle_posix.inl
+++ b/src/system/memory_mapped_file_handle_posix.inl
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 #include "memory_mapped_file_handle.hpp"
 

--- a/src/system/memory_mapped_file_handle_windows.inl
+++ b/src/system/memory_mapped_file_handle_windows.inl
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 #include "memory_mapped_file_handle.hpp"
 

--- a/tests/.clang-tidy
+++ b/tests/.clang-tidy
@@ -1,24 +1,2 @@
-#***************************************************************************
-# Authors:     Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-# 02111-1307  USA
-#
-#  All comments concerning this program package may be sent to the
-#  e-mail address 'xmipp@cnb.csic.es'
-# ***************************************************************************
-
 # Disable all checks in this folder.
 Checks: '-*'

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,25 +1,3 @@
-#***************************************************************************
-# Authors:     Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-# 02111-1307  USA
-#
-#  All comments concerning this program package may be sent to the
-#  e-mail address 'xmipp@cnb.csic.es'
-# ***************************************************************************
-
 cmake_minimum_required(VERSION 3.16)
 
 include(CTest)

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -1,25 +1,3 @@
-#***************************************************************************
-# Authors:     Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-# 02111-1307  USA
-#
-#  All comments concerning this program package may be sent to the
-#  e-mail address 'xmipp@cnb.csic.es'
-# ***************************************************************************
-
 cmake_minimum_required(VERSION 3.16)
 
 add_subdirectory(assets)

--- a/tests/integration/assets/CMakeLists.txt
+++ b/tests/integration/assets/CMakeLists.txt
@@ -1,25 +1,3 @@
-#***************************************************************************
-# Authors:     Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-# 02111-1307  USA
-#
-#  All comments concerning this program package may be sent to the
-#  e-mail address 'xmipp@cnb.csic.es'
-# ***************************************************************************
-
 add_subdirectory(dummy_plugin)
 add_subdirectory(faulty_plugin1)
 add_subdirectory(faulty_plugin2)

--- a/tests/integration/assets/dummy_plugin/CMakeLists.txt
+++ b/tests/integration/assets/dummy_plugin/CMakeLists.txt
@@ -1,25 +1,3 @@
-#***************************************************************************
-# Authors:     Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-# 02111-1307  USA
-#
-#  All comments concerning this program package may be sent to the
-#  e-mail address 'xmipp@cnb.csic.es'
-# ***************************************************************************
-
 cmake_minimum_required(VERSION 3.16)
 
 set(SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/dummy_plugin.cpp)

--- a/tests/integration/assets/dummy_plugin/dummy_plugin.cpp
+++ b/tests/integration/assets/dummy_plugin/dummy_plugin.cpp
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file dummy_plugin.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Exports a dummy plugin
- * @date 2024-10-28
- * 
- */
-
 #include <xmipp4/core/plugin.hpp>
 #include <xmipp4/core/platform/dynamic_shared_object.h>
 

--- a/tests/integration/assets/dummy_plugin/dummy_plugin.cpp
+++ b/tests/integration/assets/dummy_plugin/dummy_plugin.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file dummy_plugin.cpp

--- a/tests/integration/assets/faulty_plugin1/CMakeLists.txt
+++ b/tests/integration/assets/faulty_plugin1/CMakeLists.txt
@@ -1,25 +1,3 @@
-#***************************************************************************
-# Authors:     Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-# 02111-1307  USA
-#
-#  All comments concerning this program package may be sent to the
-#  e-mail address 'xmipp@cnb.csic.es'
-# ***************************************************************************
-
 cmake_minimum_required(VERSION 3.16)
 
 set(SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/faulty_plugin1.cpp)

--- a/tests/integration/assets/faulty_plugin1/faulty_plugin1.cpp
+++ b/tests/integration/assets/faulty_plugin1/faulty_plugin1.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file faulty_plugin1.cpp

--- a/tests/integration/assets/faulty_plugin1/faulty_plugin1.cpp
+++ b/tests/integration/assets/faulty_plugin1/faulty_plugin1.cpp
@@ -1,14 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file faulty_plugin1.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief An invalid plugin which declares the hook
- * but returns null
- * @date 2024-10-28
- * 
- */
-
 #include <xmipp4/core/plugin.hpp>
 #include <xmipp4/core/platform/dynamic_shared_object.h>
 

--- a/tests/integration/assets/faulty_plugin2/CMakeLists.txt
+++ b/tests/integration/assets/faulty_plugin2/CMakeLists.txt
@@ -1,25 +1,3 @@
-#***************************************************************************
-# Authors:     Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-# 02111-1307  USA
-#
-#  All comments concerning this program package may be sent to the
-#  e-mail address 'xmipp@cnb.csic.es'
-# ***************************************************************************
-
 cmake_minimum_required(VERSION 3.16)
 
 set(SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/faulty_plugin2.cpp)

--- a/tests/integration/assets/faulty_plugin2/faulty_plugin2.cpp
+++ b/tests/integration/assets/faulty_plugin2/faulty_plugin2.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file dummy_plugin2.cpp

--- a/tests/integration/assets/faulty_plugin2/faulty_plugin2.cpp
+++ b/tests/integration/assets/faulty_plugin2/faulty_plugin2.cpp
@@ -1,11 +1,4 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file dummy_plugin2.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Invalid plugin which does not export the plugin hook.
- * @date 2024-10-28
- * 
- */
-
-// Empty on purpose
+// Invalid plugin which does not export the plugin hook.
+// Empty on purpose.

--- a/tests/integration/src/assets.hpp
+++ b/tests/integration/src/assets.hpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file assets.hpp

--- a/tests/integration/src/assets.hpp
+++ b/tests/integration/src/assets.hpp
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file assets.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Functions to get the path to test assets
- * @date 2024-10-28
- * 
- */
-
 #include <xmipp4/core/platform/operating_system.h>
 #include <xmipp4/core/platform/compiler.h>
 

--- a/tests/integration/src/system/test_dynamic_library.cpp
+++ b/tests/integration/src/system/test_dynamic_library.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file test_dynamic_library.cpp

--- a/tests/integration/src/system/test_dynamic_library.cpp
+++ b/tests/integration/src/system/test_dynamic_library.cpp
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file test_dynamic_library.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Tests for system/dynamic_library.hpp
- * @date 2024-03-03
- * 
- */
-
 #include "../assets.hpp"
 
 #include <xmipp4/core/system/dynamic_library.hpp>

--- a/tests/integration/src/system/test_memory_mapped_file.cpp
+++ b/tests/integration/src/system/test_memory_mapped_file.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file test_memory_mapped_file.cpp

--- a/tests/integration/src/system/test_memory_mapped_file.cpp
+++ b/tests/integration/src/system/test_memory_mapped_file.cpp
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file test_memory_mapped_file.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Tests for system/memory_mapped_file.hpp
- * @date 2024-03-01
- * 
- */
-
 #include <catch2/catch_test_macros.hpp>
 
 #include <xmipp4/core/system/memory_mapped_file.hpp>

--- a/tests/integration/src/test_plugin_manager.cpp
+++ b/tests/integration/src/test_plugin_manager.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file test_plugin_manager.cpp

--- a/tests/integration/src/test_plugin_manager.cpp
+++ b/tests/integration/src/test_plugin_manager.cpp
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file test_plugin_manager.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Tests for plugin_manager.hpp
- * @date 2024-10-28
- * 
- */
-
 #include <xmipp4/core/plugin_manager.hpp>
 
 #include <xmipp4/core/plugin.hpp>

--- a/tests/unitary/CMakeLists.txt
+++ b/tests/unitary/CMakeLists.txt
@@ -1,25 +1,3 @@
-#***************************************************************************
-# Authors:     Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-# 02111-1307  USA
-#
-#  All comments concerning this program package may be sent to the
-#  e-mail address 'xmipp@cnb.csic.es'
-# ***************************************************************************
-
 cmake_minimum_required(VERSION 3.16)
 
 # Test excecutable name

--- a/tests/unitary/src/binary/test_bit.cpp
+++ b/tests/unitary/src/binary/test_bit.cpp
@@ -1,12 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file test_bit.cpp
- * @author Oier Lauzirika Zarrabeitia
- * @brief Test for binary/bit.hpp
- * @date 2023-08-09
- */
-
 #include <catch2/catch_test_macros.hpp>
 
 #include <limits>

--- a/tests/unitary/src/binary/test_bit.cpp
+++ b/tests/unitary/src/binary/test_bit.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file test_bit.cpp

--- a/tests/unitary/src/binary/test_flagset.cpp
+++ b/tests/unitary/src/binary/test_flagset.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file test_flagset.cpp

--- a/tests/unitary/src/binary/test_flagset.cpp
+++ b/tests/unitary/src/binary/test_flagset.cpp
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file test_flagset.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Test for binary/flagset.hpp
- * @date 2023-08-09
- * 
- */
-
 #include <catch2/catch_test_macros.hpp>
 
 #include <limits>

--- a/tests/unitary/src/communication/mock/mock_communicator_backend.hpp
+++ b/tests/unitary/src/communication/mock/mock_communicator_backend.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file mock_communicator_backend.cpp

--- a/tests/unitary/src/communication/mock/mock_communicator_backend.hpp
+++ b/tests/unitary/src/communication/mock/mock_communicator_backend.hpp
@@ -2,13 +2,6 @@
 
 #pragma once
 
-/**
- * @file mock_communicator_backend.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Mock for communicator_backend interface.
- * @date 2024-12-10
- */
-
 #include <xmipp4/core/communication/communicator_backend.hpp>
 
 #include <trompeloeil.hpp>

--- a/tests/unitary/src/communication/test_communicator_manager.cpp
+++ b/tests/unitary/src/communication/test_communicator_manager.cpp
@@ -1,12 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file test_communicator_manager.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Test for communicator_manager.hpp
- * @date 2024-10-29
- */
-
 #include <xmipp4/core/communication/communicator_manager.hpp>
 
 #include <xmipp4/core/exceptions/ambiguous_backend_error.hpp>

--- a/tests/unitary/src/communication/test_communicator_manager.cpp
+++ b/tests/unitary/src/communication/test_communicator_manager.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file test_communicator_manager.cpp

--- a/tests/unitary/src/compute/host/test_host_numerical_type.cpp
+++ b/tests/unitary/src/compute/host/test_host_numerical_type.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file test_host_numerical_type.cpp

--- a/tests/unitary/src/compute/host/test_host_numerical_type.cpp
+++ b/tests/unitary/src/compute/host/test_host_numerical_type.cpp
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file test_host_numerical_type.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Test for numerical type conversions.
- * @date 2024-11-19
- * 
- */
-
 #include <xmipp4/core/compute/cpu/cpu_numerical_type.hpp>
 
 #include <catch2/catch_test_macros.hpp>

--- a/tests/unitary/src/compute/mock/mock_device_backend.hpp
+++ b/tests/unitary/src/compute/mock/mock_device_backend.hpp
@@ -2,13 +2,6 @@
 
 #pragma once
 
-/**
- * @file mock_device_backend.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Mock for device_backend interface.
- * @date 2024-12-10
- */
-
 #include <xmipp4/core/compute/device_backend.hpp>
 
 #include <trompeloeil.hpp>

--- a/tests/unitary/src/compute/mock/mock_device_backend.hpp
+++ b/tests/unitary/src/compute/mock/mock_device_backend.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file mock_device_backend.cpp

--- a/tests/unitary/src/compute/mock/mock_device_buffer.hpp
+++ b/tests/unitary/src/compute/mock/mock_device_buffer.hpp
@@ -2,13 +2,6 @@
 
 #pragma once
 
-/**
- * @file mock_device_buffer.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Mock for device_buffer interface.
- * @date 2024-12-10
- */
-
 #include <xmipp4/core/compute/device_buffer.hpp>
 
 #include <trompeloeil.hpp>

--- a/tests/unitary/src/compute/mock/mock_device_buffer.hpp
+++ b/tests/unitary/src/compute/mock/mock_device_buffer.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file mock_device_buffer.cpp

--- a/tests/unitary/src/compute/mock/mock_host_buffer.hpp
+++ b/tests/unitary/src/compute/mock/mock_host_buffer.hpp
@@ -2,13 +2,6 @@
 
 #pragma once
 
-/**
- * @file mock_host_buffer.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Mock for host_buffer interface.
- * @date 2024-12-10
- */
-
 #include <xmipp4/core/compute/host_buffer.hpp>
 
 #include <trompeloeil.hpp>

--- a/tests/unitary/src/compute/mock/mock_host_buffer.hpp
+++ b/tests/unitary/src/compute/mock/mock_host_buffer.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file mock_host_buffer.cpp

--- a/tests/unitary/src/compute/test_checks.cpp
+++ b/tests/unitary/src/compute/test_checks.cpp
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file test_checks.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Tests for checks.hpp
- * @date 2024-11-12
- * 
- */
-
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers.hpp>
 

--- a/tests/unitary/src/compute/test_checks.cpp
+++ b/tests/unitary/src/compute/test_checks.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file test_checks.cpp

--- a/tests/unitary/src/compute/test_copy_region.cpp
+++ b/tests/unitary/src/compute/test_copy_region.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file test_copy_region.cpp

--- a/tests/unitary/src/compute/test_copy_region.cpp
+++ b/tests/unitary/src/compute/test_copy_region.cpp
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file test_copy_region.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Tests for copy_region.hpp
- * @date 2024-11-11
- * 
- */
-
 #include <catch2/catch_test_macros.hpp>
 
 #include <xmipp4/core/compute/copy_region.hpp>

--- a/tests/unitary/src/compute/test_device_buffer.cpp
+++ b/tests/unitary/src/compute/test_device_buffer.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file test_device_buffer.cpp

--- a/tests/unitary/src/compute/test_device_buffer.cpp
+++ b/tests/unitary/src/compute/test_device_buffer.cpp
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file test_device_buffer.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Tests for device_buffer.hpp
- * @date 2024-11-09
- * 
- */
-
 #include <xmipp4/core/compute/device_queue.hpp>
 
 #include "mock/mock_device_buffer.hpp"

--- a/tests/unitary/src/compute/test_device_index.cpp
+++ b/tests/unitary/src/compute/test_device_index.cpp
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file test_device_index.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Tests for device_index.hpp
- * @date 2024-10-29
- * 
- */
-
 #include <catch2/catch_test_macros.hpp>
 
 #include <xmipp4/core/compute/device_index.hpp>

--- a/tests/unitary/src/compute/test_device_index.cpp
+++ b/tests/unitary/src/compute/test_device_index.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file test_device_index.cpp

--- a/tests/unitary/src/compute/test_device_manager.cpp
+++ b/tests/unitary/src/compute/test_device_manager.cpp
@@ -1,12 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file test_device_manager.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Test for device_manager.hpp
- * @date 2024-10-29
- */
-
 #include <xmipp4/core/compute/device_manager.hpp>
 
 #include <xmipp4/core/compute/device.hpp>

--- a/tests/unitary/src/compute/test_device_manager.cpp
+++ b/tests/unitary/src/compute/test_device_manager.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file test_device_manager.cpp

--- a/tests/unitary/src/compute/test_device_properties.cpp
+++ b/tests/unitary/src/compute/test_device_properties.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file test_device_properties.cpp

--- a/tests/unitary/src/compute/test_device_properties.cpp
+++ b/tests/unitary/src/compute/test_device_properties.cpp
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file test_device_properties.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Tests for device_properties.hpp
- * @date 2024-10-25
- * 
- */
-
 #include <catch2/catch_test_macros.hpp>
 
 #include <xmipp4/core/compute/device_properties.hpp>

--- a/tests/unitary/src/compute/test_host_buffer.cpp
+++ b/tests/unitary/src/compute/test_host_buffer.cpp
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file test_host_buffer.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Tests for host_buffer.hpp
- * @date 2024-11-09
- * 
- */
-
 #include <xmipp4/core/compute/host_buffer.hpp>
 #include <xmipp4/core/compute/device_queue.hpp>
 

--- a/tests/unitary/src/compute/test_host_buffer.cpp
+++ b/tests/unitary/src/compute/test_host_buffer.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file test_host_buffer.cpp

--- a/tests/unitary/src/compute/test_numerical_type.cpp
+++ b/tests/unitary/src/compute/test_numerical_type.cpp
@@ -64,4 +64,3 @@ TEST_CASE( "from_string with numerical_type should produce correct results", "[n
     REQUIRE( from_string("complex_float64", type) );
     REQUIRE( type == numerical_type::complex_float64 );
 }
-

--- a/tests/unitary/src/compute/test_numerical_type.cpp
+++ b/tests/unitary/src/compute/test_numerical_type.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file test_numerical_type.cpp

--- a/tests/unitary/src/compute/test_numerical_type.cpp
+++ b/tests/unitary/src/compute/test_numerical_type.cpp
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file test_numerical_type.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Test for numerical_type.hpp
- * @date 2025-03-27
- */
-
-
 #include <catch2/catch_test_macros.hpp>
 
 #include <xmipp4/core/compute/numerical_type.hpp>
@@ -72,5 +64,4 @@ TEST_CASE( "from_string with numerical_type should produce correct results", "[n
     REQUIRE( from_string("complex_float64", type) );
     REQUIRE( type == numerical_type::complex_float64 );
 }
-
 

--- a/tests/unitary/src/concurrency/test_semaphore.cpp
+++ b/tests/unitary/src/concurrency/test_semaphore.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file semaphore.cpp

--- a/tests/unitary/src/concurrency/test_semaphore.cpp
+++ b/tests/unitary/src/concurrency/test_semaphore.cpp
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file semaphore.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Tests for concurrency/semaphore.hpp
- * @date 2024-09-25
- * 
- */
-
 #include <catch2/catch_test_macros.hpp>
 
 #include <xmipp4/core/concurrency/semaphore.hpp>

--- a/tests/unitary/src/image/test_location.cpp
+++ b/tests/unitary/src/image/test_location.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file test_location.cpp

--- a/tests/unitary/src/image/test_location.cpp
+++ b/tests/unitary/src/image/test_location.cpp
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file test_location.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Tests for image/location.hpp
- * @date 2024-05-15
- * 
- */
-
 #include <catch2/catch_test_macros.hpp>
 
 #include <xmipp4/core/image/location.hpp>

--- a/tests/unitary/src/math/test_abs.cpp
+++ b/tests/unitary/src/math/test_abs.cpp
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file test_abs.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Tests for abs.hpp
- * @date 2024-04-11
- * 
- */
-
 #include <catch2/catch_test_macros.hpp>
 
 #include <xmipp4/core/math/abs.hpp>

--- a/tests/unitary/src/math/test_abs.cpp
+++ b/tests/unitary/src/math/test_abs.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file test_abs.cpp

--- a/tests/unitary/src/math/test_arithmetic.cpp
+++ b/tests/unitary/src/math/test_arithmetic.cpp
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file test_arithmetic.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Tests for arithmetic.hpp
- * @date 2024-04-15
- * 
- */
-
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/catch_approx.hpp>
 

--- a/tests/unitary/src/math/test_arithmetic.cpp
+++ b/tests/unitary/src/math/test_arithmetic.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file test_arithmetic.cpp

--- a/tests/unitary/src/math/test_bessel.cpp
+++ b/tests/unitary/src/math/test_bessel.cpp
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file test_bessel.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Tests for bessel.hpp
- * @date 2024-04-11
- * 
- */
-
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/catch_approx.hpp>
 

--- a/tests/unitary/src/math/test_bessel.cpp
+++ b/tests/unitary/src/math/test_bessel.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file test_bessel.cpp

--- a/tests/unitary/src/math/test_bspline.cpp
+++ b/tests/unitary/src/math/test_bspline.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file test_bspline.cpp

--- a/tests/unitary/src/math/test_bspline.cpp
+++ b/tests/unitary/src/math/test_bspline.cpp
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file test_bspline.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Tests for bspline.hpp
- * @date 2024-10-24
- * 
- */
-
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/catch_approx.hpp>
 

--- a/tests/unitary/src/math/test_erf.cpp
+++ b/tests/unitary/src/math/test_erf.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file test_erf.cpp

--- a/tests/unitary/src/math/test_erf.cpp
+++ b/tests/unitary/src/math/test_erf.cpp
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file test_erf.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Tests for erf.hpp
- * @date 2024-04-12
- * 
- */
-
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/catch_approx.hpp>
 

--- a/tests/unitary/src/math/test_exponential.cpp
+++ b/tests/unitary/src/math/test_exponential.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file test_exponential.cpp

--- a/tests/unitary/src/math/test_exponential.cpp
+++ b/tests/unitary/src/math/test_exponential.cpp
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file test_exponential.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Tests for exponential.hpp
- * @date 2024-04-12
- * 
- */
-
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/catch_approx.hpp>
 

--- a/tests/unitary/src/math/test_factorial.cpp
+++ b/tests/unitary/src/math/test_factorial.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file test_factorial.cpp

--- a/tests/unitary/src/math/test_factorial.cpp
+++ b/tests/unitary/src/math/test_factorial.cpp
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file test_factorial.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Tests for factorial.hpp
- * @date 2024-04-12
- * 
- */
-
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/catch_approx.hpp>
 

--- a/tests/unitary/src/math/test_hyperbolic.cpp
+++ b/tests/unitary/src/math/test_hyperbolic.cpp
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file test_hyperbolic.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Tests for hyperbolic.hpp
- * @date 2024-04-15
- * 
- */
-
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/catch_approx.hpp>
 

--- a/tests/unitary/src/math/test_hyperbolic.cpp
+++ b/tests/unitary/src/math/test_hyperbolic.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file test_hyperbolic.cpp

--- a/tests/unitary/src/math/test_nearest_integer.cpp
+++ b/tests/unitary/src/math/test_nearest_integer.cpp
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file test_nearest_integer.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Tests for nearest_integer.hpp
- * @date 2024-04-15
- * 
- */
-
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/catch_approx.hpp>
 

--- a/tests/unitary/src/math/test_nearest_integer.cpp
+++ b/tests/unitary/src/math/test_nearest_integer.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file test_nearest_integer.cpp

--- a/tests/unitary/src/math/test_power.cpp
+++ b/tests/unitary/src/math/test_power.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file test_power.cpp

--- a/tests/unitary/src/math/test_power.cpp
+++ b/tests/unitary/src/math/test_power.cpp
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file test_power.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Tests for power.hpp
- * @date 2024-04-12
- * 
- */
-
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/catch_approx.hpp>
 

--- a/tests/unitary/src/math/test_trigonometric.cpp
+++ b/tests/unitary/src/math/test_trigonometric.cpp
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file test_trigonometric.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Tests for trigonometric.hpp
- * @date 2024-04-12
- * 
- */
-
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/catch_approx.hpp>
 

--- a/tests/unitary/src/math/test_trigonometric.cpp
+++ b/tests/unitary/src/math/test_trigonometric.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file test_trigonometric.cpp

--- a/tests/unitary/src/memory/test_align.cpp
+++ b/tests/unitary/src/memory/test_align.cpp
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file test_align.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Tests for memory/align.hpp
- * @date 2024-03-10
- * 
- */
-
 #include <catch2/catch_test_macros.hpp>
 
 #include <xmipp4/core/memory/align.hpp>

--- a/tests/unitary/src/memory/test_align.cpp
+++ b/tests/unitary/src/memory/test_align.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file test_align.cpp

--- a/tests/unitary/src/memory/test_aligned_alloc.cpp
+++ b/tests/unitary/src/memory/test_aligned_alloc.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file test_aligned_alloc.cpp

--- a/tests/unitary/src/memory/test_aligned_alloc.cpp
+++ b/tests/unitary/src/memory/test_aligned_alloc.cpp
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file test_aligned_alloc.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Tests for memory/aligned_alloc.hpp
- * @date 2024-12-02
- * 
- */
-
 
 #include <xmipp4/core/memory/aligned_alloc.hpp>
 

--- a/tests/unitary/src/memory/test_byte_order.cpp
+++ b/tests/unitary/src/memory/test_byte_order.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file test_byte_order.cpp

--- a/tests/unitary/src/memory/test_byte_order.cpp
+++ b/tests/unitary/src/memory/test_byte_order.cpp
@@ -1,12 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file test_byte_order.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Test for binary/byte_order.hpp
- * @date 2023-08-12
- */
-
 #include <catch2/catch_test_macros.hpp>
 
 #include <xmipp4/core/memory/byte_order.hpp>

--- a/tests/unitary/src/memory/test_byte_order.cpp
+++ b/tests/unitary/src/memory/test_byte_order.cpp
@@ -41,4 +41,3 @@ TEST_CASE( "reverse byte order", "[byte_order]" )
         REQUIRE( reverse_byte_order(uint64_t(0x123456789ABCDEF0)) == 0xF0DEBC9A78563412 );
     }
 }
-

--- a/tests/unitary/src/memory/test_pimpl.cpp
+++ b/tests/unitary/src/memory/test_pimpl.cpp
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file test_pimpl.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Tests for memory/pimpl.hpp
- * @date 2024-03-10
- * 
- */
-
 #include <catch2/catch_test_macros.hpp>
 
 #include <xmipp4/core/memory/pimpl.hpp>

--- a/tests/unitary/src/memory/test_pimpl.cpp
+++ b/tests/unitary/src/memory/test_pimpl.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file test_pimpl.cpp

--- a/tests/unitary/src/mock/mock_backend.hpp
+++ b/tests/unitary/src/mock/mock_backend.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file mock_backend.hpp

--- a/tests/unitary/src/mock/mock_backend.hpp
+++ b/tests/unitary/src/mock/mock_backend.hpp
@@ -2,13 +2,6 @@
 
 #pragma once
 
-/**
- * @file mock_backend.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Mock for backend interface.
- * @date 2025-03-27
- */
-
 #include <xmipp4/core/backend.hpp>
 
 #include <trompeloeil.hpp>

--- a/tests/unitary/src/mock/mock_backend_manager.hpp
+++ b/tests/unitary/src/mock/mock_backend_manager.hpp
@@ -2,13 +2,6 @@
 
 #pragma once
 
-/**
- * @file mock_backend_manager.hpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Mock for backend_manager interface.
- * @date 2025-03-27
- */
-
 #include <xmipp4/core/backend_manager.hpp>
 
 #include <trompeloeil.hpp>

--- a/tests/unitary/src/mock/mock_backend_manager.hpp
+++ b/tests/unitary/src/mock/mock_backend_manager.hpp
@@ -1,24 +1,6 @@
-#pragma once
+// SPDX-License-Identifier: GPL-3.0-only
 
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+#pragma once
 
 /**
  * @file mock_backend_manager.hpp

--- a/tests/unitary/src/multidimensional/test_axis_descriptor.cpp
+++ b/tests/unitary/src/multidimensional/test_axis_descriptor.cpp
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file test_axis_descriptor.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Tests for multidimensional/axis_descriptor.hpp
- * @date 2024-05-08
- * 
- */
-
 #include <catch2/catch_test_macros.hpp>
 
 #include <xmipp4/core/multidimensional/axis_descriptor.hpp>

--- a/tests/unitary/src/multidimensional/test_axis_descriptor.cpp
+++ b/tests/unitary/src/multidimensional/test_axis_descriptor.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file test_axis_descriptor.cpp

--- a/tests/unitary/src/multidimensional/test_strided_layout_utils.cpp
+++ b/tests/unitary/src/multidimensional/test_strided_layout_utils.cpp
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file test_memory_layout.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Tests for multidimensional/strided_layout_utils.hpp
- * @date 2023-09-25
- * 
- */
-
 #include <catch2/catch_test_macros.hpp>
 
 #include <xmipp4/core/multidimensional/strided_layout_utils.hpp>

--- a/tests/unitary/src/multidimensional/test_strided_layout_utils.cpp
+++ b/tests/unitary/src/multidimensional/test_strided_layout_utils.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file test_memory_layout.cpp

--- a/tests/unitary/src/reduction_operation.cpp
+++ b/tests/unitary/src/reduction_operation.cpp
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file test_reduction_operation.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Test for reduction_operation.hpp
- * @date 2025-03-27
- */
-
-
 #include <catch2/catch_test_macros.hpp>
 
 #include <xmipp4/core/reduction_operation.hpp>
@@ -38,4 +30,3 @@ TEST_CASE( "from_string with reduction_operation should produce correct results"
     
     REQUIRE( !from_string("invalid", op) );
 }
-

--- a/tests/unitary/src/reduction_operation.cpp
+++ b/tests/unitary/src/reduction_operation.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file test_reduction_operation.cpp

--- a/tests/unitary/src/test_access_flags.cpp
+++ b/tests/unitary/src/test_access_flags.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file test_access_flags.cpp

--- a/tests/unitary/src/test_access_flags.cpp
+++ b/tests/unitary/src/test_access_flags.cpp
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file test_access_flags.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Test for access_flags.hpp
- * @date 2025-03-27
- */
-
-
 #include <catch2/catch_test_macros.hpp>
 
 #include <xmipp4/core/access_flags.hpp>

--- a/tests/unitary/src/test_axis_3d.cpp
+++ b/tests/unitary/src/test_axis_3d.cpp
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file test_axis_3d.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Tests for axis_3d.hpp
- * @date 2023-09-25
- * 
- */
-
 #include <catch2/catch_test_macros.hpp>
 
 #include <xmipp4/core/axis_3d.hpp>

--- a/tests/unitary/src/test_axis_3d.cpp
+++ b/tests/unitary/src/test_axis_3d.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file test_axis_3d.cpp

--- a/tests/unitary/src/test_backend_manager.cpp
+++ b/tests/unitary/src/test_backend_manager.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file test_interface_catalog.cpp

--- a/tests/unitary/src/test_backend_manager.cpp
+++ b/tests/unitary/src/test_backend_manager.cpp
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file test_interface_catalog.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Tests for interface_catalog.hpp
- * @date 2024-10-28
- * 
- */
-
 #include <xmipp4/core/backend_manager.hpp>
 
 #include "mock/mock_backend.hpp"

--- a/tests/unitary/src/test_interface_catalog.cpp
+++ b/tests/unitary/src/test_interface_catalog.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file test_interface_catalog.cpp

--- a/tests/unitary/src/test_interface_catalog.cpp
+++ b/tests/unitary/src/test_interface_catalog.cpp
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file test_interface_catalog.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Tests for interface_catalog.hpp
- * @date 2024-10-28
- * 
- */
-
 #include <xmipp4/core/interface_catalog.hpp>
 
 #include "mock/mock_backend_manager.hpp"

--- a/tests/unitary/src/test_slice.cpp
+++ b/tests/unitary/src/test_slice.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file test_slice.cpp

--- a/tests/unitary/src/test_slice.cpp
+++ b/tests/unitary/src/test_slice.cpp
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file test_slice.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Tests for slice.hpp
- * @date 2024-02-28
- * 
- */
-
 #include <catch2/catch_test_macros.hpp>
 
 #include <xmipp4/core/slice.hpp>

--- a/tests/unitary/src/test_span.cpp
+++ b/tests/unitary/src/test_span.cpp
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file test_slice.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Tests for slice.hpp
- * @date 2024-02-28
- * 
- */
-
 #include <catch2/catch_test_macros.hpp>
 
 #include <xmipp4/core/span.hpp>

--- a/tests/unitary/src/test_span.cpp
+++ b/tests/unitary/src/test_span.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file test_slice.cpp

--- a/tests/unitary/src/test_version.cpp
+++ b/tests/unitary/src/test_version.cpp
@@ -1,22 +1,4 @@
-/***************************************************************************
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
- * 02111-1307  USA
- *
- *  All comments concerning this program package may be sent to the
- *  e-mail address 'xmipp@cnb.csic.es'
- ***************************************************************************/
+// SPDX-License-Identifier: GPL-3.0-only
 
 /**
  * @file test_version.cpp

--- a/tests/unitary/src/test_version.cpp
+++ b/tests/unitary/src/test_version.cpp
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * @file test_version.cpp
- * @author Oier Lauzirika Zarrabeitia (oierlauzi@bizkaia.eu)
- * @brief Test for version.hpp
- * @date 2023-08-12
- */
-
-
 #include <catch2/catch_test_macros.hpp>
 
 #include <xmipp4/core/version.hpp>


### PR DESCRIPTION
Also:
- Removed redundant doxygen file headers
- Removed double line breaks