### PR TITLE
Also dry run deploy pipeline on dependabot Pull Requests

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,6 +52,7 @@ jobs:
 
   build_sdist:
     name: Build source distribution
+    if: github.event_name != 'pull_request' || startsWith(github.head_ref, 'dependabot/')
     permissions:
       contents: read
     runs-on: ubuntu-latest
@@ -92,6 +93,7 @@ jobs:
     name: Build conda packages
     permissions:
       contents: read
+    if: github.event_name != 'pull_request' || startsWith(github.head_ref, 'dependabot/')
     strategy:
       matrix:
         os:
@@ -149,6 +151,7 @@ jobs:
     name: Build Doxygen documentation
     permissions:
       contents: read
+    if: github.event_name != 'pull_request' || startsWith(github.head_ref, 'dependabot/')
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - main
 
+  pull_request:
+    branches:
+      - main
+
   workflow_dispatch:
 
 jobs:
@@ -15,6 +19,7 @@ jobs:
     name: Build wheels for ${{ matrix.os }} (${{ matrix.architectures }})
     permissions:
       contents: read
+    if: github.event_name != 'pull_request' || startsWith(github.head_ref, 'dependabot/')
     strategy:
       matrix:
         include:
@@ -178,7 +183,7 @@ jobs:
     permissions:
       pages: write
       id-token: write
-    if: startsWith(github.event.ref, 'refs/tags/v')
+    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,9 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - '.github/workflows/deploy.yml'
+      - 'pyproject.toml'
 
   workflow_dispatch:
 
@@ -19,7 +22,6 @@ jobs:
     name: Build wheels for ${{ matrix.os }} (${{ matrix.architectures }})
     permissions:
       contents: read
-    if: github.event_name != 'pull_request' || startsWith(github.head_ref, 'dependabot/')
     strategy:
       matrix:
         include:
@@ -52,7 +54,6 @@ jobs:
 
   build_sdist:
     name: Build source distribution
-    if: github.event_name != 'pull_request' || startsWith(github.head_ref, 'dependabot/')
     permissions:
       contents: read
     runs-on: ubuntu-latest
@@ -93,7 +94,6 @@ jobs:
     name: Build conda packages
     permissions:
       contents: read
-    if: github.event_name != 'pull_request' || startsWith(github.head_ref, 'dependabot/')
     strategy:
       matrix:
         os:
@@ -151,7 +151,6 @@ jobs:
     name: Build Doxygen documentation
     permissions:
       contents: read
-    if: github.event_name != 'pull_request' || startsWith(github.head_ref, 'dependabot/')
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository


### PR DESCRIPTION
This way we won't need to manually run the deploy pipeline every time dependabot opens a Pull Request updating some dependency, as it will have already run.