### PR TITLE
Swap deprecated external action with replacement one

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,10 +38,10 @@ jobs:
     
     - name: Generate GitHub App Token
       id: generate_token
-      uses: tibdex/github-app-token@v2
+      uses: actions/create-github-app-token@v2
       with:
-        app_id: ${{ secrets.W2W_APP_ID }}
-        private_key: ${{ secrets.W2W_APP_PRIVATE_KEY }}
+        app-id: ${{ secrets.W2W_APP_ID }}
+        private-key: ${{ secrets.W2W_APP_PRIVATE_KEY }}
 
     - name: Generate tag
       id: tag_version


### PR DESCRIPTION
[Original action repo](https://github.com/tibdex/github-app-token) is now in archived in read-only mode and it's own page suggests migrating to the new one.