### PR TITLE
Remove Dependabot update grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,10 +4,3 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    groups:
-      # Group all non-major updates into a single Pull Request
-      minor-and-patch:
-        applies-to: version-updates
-        update-types:
-        - "minor"
-        - "patch"


### PR DESCRIPTION
Sometimes a minor or patch update in a dependency can break it (seen with [Jimver/cuda-toolkit](https://github.com/Jimver/cuda-toolkit)).

Maybe it's a better idea to keep every update in it's own PR so that they don't affect each other.