### PR TITLE
Fix issue with IN_SEQUENCE for MSVC

### DIFF
--- a/tests/unitary/CMakeLists.txt
+++ b/tests/unitary/CMakeLists.txt
@@ -24,6 +24,15 @@ target_link_libraries(
 		trompeloeil::trompeloeil
 )
 
+# HACK: Required for TROMPELOEIL_COUNT() to work with MSVC
+if(MSVC)
+	target_compile_options(
+		${TESTS_NAME}
+		PRIVATE
+			/Zc:preprocessor 
+	)
+endif()
+
 # On windows targets, copy the library to the test directory
 if(WIN32)
 	add_custom_command(TARGET ${TESTS_NAME}

--- a/tests/unitary/src/hardware/caching_memory_allocator/test_caching_memory_allocator.cpp
+++ b/tests/unitary/src/hardware/caching_memory_allocator/test_caching_memory_allocator.cpp
@@ -8,7 +8,6 @@
 
 #include <xmipp4/core/hardware/buffer.hpp>
 #include <xmipp4/core/hardware/buffer_sentinel.hpp>
-#include <xmipp4/core/platform/compiler.h> // FIXME IN_SEQUENCE does not work with MSVC
 
 #include "../mock/mock_device_queue.hpp"
 #include "../mock/mock_memory_resource.hpp"
@@ -126,8 +125,6 @@ TEST_CASE( "requesting an over-aligned buffer from caching_memory_allocator shou
 	);
 }
 
-#if !XMIPP4_MSVC // FIXME IN_SEQUENCE not working with MSVC
-
 TEST_CASE( "requesting a buffer from caching_allocator should retry after freeing resources when an allocation fails", "[caching_memory_allocator_backend]" )
 {
     const std::size_t max_alignment = 256;
@@ -183,8 +180,6 @@ TEST_CASE( "requesting a buffer from caching_allocator should retry after freein
         allocator.allocate(request_size_step+1, 32, nullptr);
     }
 }
-
-#endif // !XMIPP4_MSVC
 
 TEST_CASE( "requesting a buffer from caching_allocator should throw when allocation fails repeatedly", "[caching_memory_allocator_backend]" )
 {

--- a/tests/unitary/src/hardware/caching_memory_allocator/test_memory_block_deferred_release.cpp
+++ b/tests/unitary/src/hardware/caching_memory_allocator/test_memory_block_deferred_release.cpp
@@ -6,7 +6,6 @@
 #include <hardware/caching_memory_allocator/memory_block_deferred_release.hpp>
 
 #include <xmipp4/core/hardware/buffer_sentinel.hpp>
-#include <xmipp4/core/platform/compiler.h> // FIXME IN_SEQUENCE does not work with MSVC
 
 #include "../mock/mock_device.hpp"
 #include "../mock/mock_device_queue.hpp"
@@ -61,8 +60,6 @@ TEST_CASE( "deferring a release in memory_block_deferred_release with a null que
 		Catch::Matchers::Message("nullptr queue was provided")
 	);
 }
-
-#if !XMIPP4_MSVC // FIXME: For some reason IN_SEQUENCE does not work with MSVC
 
 TEST_CASE( "deferring a release in memory_block_deferred_release should create and signal an event per queue", "[caching_memory_allocator]" )
 {
@@ -284,5 +281,3 @@ TEST_CASE( "repeated use cycle of memory_block_deferred release should reuse its
         REQUIRE( ite->second.is_free() );
     }
 }
-
-#endif // !XMIPP4_MSVC

--- a/tests/unitary/src/hardware/test_memory_allocator_manager.cpp
+++ b/tests/unitary/src/hardware/test_memory_allocator_manager.cpp
@@ -2,13 +2,13 @@
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_exception.hpp>
+#include <trompeloeil/sequence.hpp>
 
 #include <xmipp4/core/hardware/memory_allocator_manager.hpp>
 
 #include <xmipp4/core/hardware/memory_resource.hpp>
 #include <xmipp4/core/hardware/memory_allocator.hpp>
 #include <xmipp4/core/exceptions/invalid_operation_error.hpp>
-#include <xmipp4/core/platform/compiler.h> // FIXME IN_SEQUENCE does not work with windows
 
 #include "mock/mock_memory_allocator_backend.hpp"
 #include "mock/mock_memory_allocator.hpp"
@@ -48,8 +48,6 @@ TEST_CASE( "creating a allocator from a default initialized memory_allocator_man
 	);
 }
 
-#if !XMIPP4_MSVC // FIXME IN_SEQUENCE does not work with windows
-
 TEST_CASE( "memory_allocator_manager should use the most suitable backend", "[memory_allocator_backend]" )
 {
     memory_allocator_manager manager;
@@ -81,8 +79,6 @@ TEST_CASE( "memory_allocator_manager should use the most suitable backend", "[me
 
     REQUIRE( manager.create_memory_allocator(resource) == allocator );
 }
-
-#endif // !XMIPP4_MSVC
 
 TEST_CASE( "memory_allocator_manager should throw when there is no supported backend", "[memory_allocator_backend]" )
 {

--- a/tests/unitary/src/hardware/test_memory_transfer_manager.cpp
+++ b/tests/unitary/src/hardware/test_memory_transfer_manager.cpp
@@ -8,7 +8,6 @@
 #include <xmipp4/core/hardware/memory_resource.hpp>
 #include <xmipp4/core/hardware/memory_transfer.hpp>
 #include <xmipp4/core/exceptions/invalid_operation_error.hpp>
-#include <xmipp4/core/platform/compiler.h> // FIXME IN_SEQUENCE does not work with windows
 
 #include "mock/mock_memory_transfer_backend.hpp"
 #include "mock/mock_memory_transfer.hpp"
@@ -47,8 +46,6 @@ TEST_CASE( "creating a transfer from a default initialized memory_transfer_manag
         )
 	);
 }
-
-#if !XMIPP4_MSVC // FIXME IN_SEQUENCE does not work with windows
 
 TEST_CASE( "memory_transfer_manager should use the most suitable backend", "[memory_transfer_backend]" )
 {
@@ -119,8 +116,6 @@ TEST_CASE( "memory_transfer_manager should cache the transfers", "[memory_transf
         REQUIRE( manager.create_transfer(source, destination) == transfer );
     }
 }
-
-#endif // !XMIPP4_MSVC
 
 TEST_CASE( "memory_transfer_manager should throw when there is no supported backend", "[memory_transfer_backend]" )
 {


### PR DESCRIPTION
Tests involving sequences, were disabled for MSVC because this produced compilation errors. This fixes those compilation errors and re-enables those tests. Closes https://github.com/gigabit-clowns/xmipp4-core/issues/257