### PR TITLE
Update conda action param

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -108,7 +108,7 @@ jobs:
       - name: Set up conda
         uses: conda-incubator/setup-miniconda@v3
         with:
-          auto-activate-base: true
+          auto-activate: true
           activate-environment: "" # Base is required for conda-build
 
       - name: Install conda-build and conda-verify

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -112,7 +112,7 @@ jobs:
       - name: Set up conda
         uses: conda-incubator/setup-miniconda@v3
         with:
-          auto-activate-base: true
+          auto-activate: true
           activate-environment: "" # Base is required for conda-build
 
       - name: Install conda-build and conda-verify


### PR DESCRIPTION
We were getting this warning on every run of the `build_and_test` and `deploy` workflows:
```
conda (...)
WARNING conda.cli.main_config:_set_key(451): Key auto_activate_base is an alias of auto_activate; setting value with latter
```