### PR TITLE
Disable coverage on windows MSVC

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -45,6 +45,7 @@ jobs:
 
       - name: Install coverage tool
         id: install-coverage
+        if: matrix.compiler.c != 'cl' && matrix.compiler.cxx != 'cl'
         uses: gigabit-clowns/.github/.github/composites/install-cpp-coverage-tool@main
         with:
           compiler-c: ${{ matrix.compiler.c }}
@@ -69,6 +70,7 @@ jobs:
         uses: gigabit-clowns/.github/.github/composites/run-ctest@main
 
       - name: Generate coverage report
+        if: matrix.compiler.c != 'cl' && matrix.compiler.cxx != 'cl'
         uses: gigabit-clowns/.github/.github/composites/run-ctest/coverage-report@main
         with:
           compiler-c: ${{ matrix.compiler.c }}


### PR DESCRIPTION
Instrumentation for Windows with MSVC (OpenCppCoverage) uses a very inefficient coverage tracking method, which can make coverage generation very slow, and also produce wrong metrics due to instrumenting compiled code rather than source code, which causes some lines not being present due to compiler optimizations.