### PR TITLE
Hiding symbols by default

### DIFF
--- a/include/xmipp4/core/exceptions/ambiguous_backend_error.hpp
+++ b/include/xmipp4/core/exceptions/ambiguous_backend_error.hpp
@@ -4,6 +4,8 @@
 
 #include <stdexcept>
 
+#include <xmipp4/core/platform/dynamic_shared_object.h>
+
 namespace xmipp4 
 {
 
@@ -12,7 +14,7 @@ namespace xmipp4
  * backend candidates.
  * 
  */
-class ambiguous_backend_error
+class XMIPP4_CORE_API ambiguous_backend_error
 	: public std::runtime_error
 {
 	using runtime_error::runtime_error;

--- a/include/xmipp4/core/exceptions/invalid_operation_error.hpp
+++ b/include/xmipp4/core/exceptions/invalid_operation_error.hpp
@@ -4,6 +4,8 @@
 
 #include <stdexcept>
 
+#include <xmipp4/core/platform/dynamic_shared_object.h>
+
 namespace xmipp4 
 {
 
@@ -12,7 +14,7 @@ namespace xmipp4
  * a misconfiguration of the class.
  * 
  */
-class invalid_operation_error
+class XMIPP4_CORE_API invalid_operation_error
 	: public std::logic_error
 {
 	using logic_error::logic_error;

--- a/include/xmipp4/core/exceptions/plugin_load_error.hpp
+++ b/include/xmipp4/core/exceptions/plugin_load_error.hpp
@@ -4,6 +4,8 @@
 
 #include <stdexcept>
 
+#include <xmipp4/core/platform/dynamic_shared_object.h>
+
 namespace xmipp4 
 {
 
@@ -12,7 +14,7 @@ namespace xmipp4
  * a plugin.
  * 
  */
-class plugin_load_error
+class XMIPP4_CORE_API plugin_load_error
 	: public std::runtime_error
 {
 	using runtime_error::runtime_error;

--- a/include/xmipp4/core/platform/dynamic_shared_object.h
+++ b/include/xmipp4/core/platform/dynamic_shared_object.h
@@ -41,7 +41,8 @@
 
 /**
  * @def XMIPP4_LOCAL
- * @brief Declares that the function is only used used locally at the current shared object
+ * @brief Declares that the function is only used used locally at the current 
+ * shared object
  * 
  */
 #if defined(XMIPP4_WINDOWS)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,6 +15,8 @@ set_target_properties(
 	PROPERTIES 
 		SOVERSION ${PROJECT_VERSION}
 		DEFINE_SYMBOL XMIPP4_CORE_EXPORTING
+		C_VISIBILITY_PRESET hidden
+    	CXX_VISIBILITY_PRESET hidden
 )
 target_include_directories(
 	xmipp4-core


### PR DESCRIPTION
Makes binaries with GCC and Clang smaller as it gives the linker the chance to remove unreachable code from the final binary. Already the default behavior in MSVC.