### PR TITLE
Using a macro for to_string cases

### DIFF
--- a/include/xmipp4/core/access_flags.inl
+++ b/include/xmipp4/core/access_flags.inl
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 #include "access_flags.hpp"
+#include "platform/enum_helpers.hpp"
 
 namespace xmipp4 
 {
@@ -10,8 +11,8 @@ to_string(access_flag_bits v) noexcept
 {
 	switch (v)
 	{
-	case access_flag_bits::read:    return "read";
-	case access_flag_bits::write:   return "write";
+	XMIPP4_ENUM_TO_STR_CASE(access_flag_bits, read)
+	XMIPP4_ENUM_TO_STR_CASE(access_flag_bits, write)
 	default: return "";
 	}
 }

--- a/include/xmipp4/core/backend_priority.inl
+++ b/include/xmipp4/core/backend_priority.inl
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 #include "backend_priority.hpp"
+#include "platform/enum_helpers.hpp"
 
 namespace xmipp4 
 {
@@ -36,10 +37,10 @@ const char* to_string(backend_priority priority) noexcept
 {
 	switch (priority)
 	{
-	case backend_priority::unsupported: return "unsupported";
-	case backend_priority::fallback: return "fallback";
-	case backend_priority::normal: return "normal";
-	case backend_priority::optimal: return "optimal";
+	XMIPP4_ENUM_TO_STR_CASE(backend_priority, unsupported)
+	XMIPP4_ENUM_TO_STR_CASE(backend_priority, fallback)
+	XMIPP4_ENUM_TO_STR_CASE(backend_priority, normal)
+	XMIPP4_ENUM_TO_STR_CASE(backend_priority, optimal)
 	default: return "";
 	}
 }

--- a/include/xmipp4/core/communication/reduction_operation.inl
+++ b/include/xmipp4/core/communication/reduction_operation.inl
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "reduction_operation.hpp"
+#include "../platform/enum_helpers.hpp"
 
 namespace xmipp4
 {
@@ -14,10 +15,10 @@ const char* to_string(reduction_operation op) noexcept
 {
 	switch (op)
 	{
-	case reduction_operation::sum: return "sum";
-	case reduction_operation::product: return "product";
-	case reduction_operation::min: return "min";
-	case reduction_operation::max: return "max";
+	XMIPP4_ENUM_TO_STR_CASE(reduction_operation, sum)
+	XMIPP4_ENUM_TO_STR_CASE(reduction_operation, product)
+	XMIPP4_ENUM_TO_STR_CASE(reduction_operation, min)
+	XMIPP4_ENUM_TO_STR_CASE(reduction_operation, max)
 	default: return "";
 	}
 }

--- a/include/xmipp4/core/multidimensional/multi_array_access_layout_build_flags.inl
+++ b/include/xmipp4/core/multidimensional/multi_array_access_layout_build_flags.inl
@@ -14,9 +14,13 @@ const char* to_string(multi_array_access_layout_build_flag_bits x) noexcept
 	switch (x)
 	{
 	XMIPP4_ENUM_TO_STR_CASE(
-		multi_array_access_layout_build_flag_bits, enable_reordering)
+		multi_array_access_layout_build_flag_bits, 
+		enable_reordering
+	)
 	XMIPP4_ENUM_TO_STR_CASE(
-		multi_array_access_layout_build_flag_bits, enable_coalescing)
+		multi_array_access_layout_build_flag_bits, 
+		enable_coalescing
+	)
 	default: return "";
 	}
 }

--- a/include/xmipp4/core/multidimensional/multi_array_access_layout_build_flags.inl
+++ b/include/xmipp4/core/multidimensional/multi_array_access_layout_build_flags.inl
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 #include "multi_array_access_layout_build_flags.hpp"
+#include "../platform/enum_helpers.hpp"
 
 namespace xmipp4 
 {
@@ -12,10 +13,10 @@ const char* to_string(multi_array_access_layout_build_flag_bits x) noexcept
 {
 	switch (x)
 	{
-	case multi_array_access_layout_build_flag_bits::enable_reordering:     
-		return "enable_reordering";
-	case multi_array_access_layout_build_flag_bits::enable_coalescing:
-		return "enable_coalescing";
+	XMIPP4_ENUM_TO_STR_CASE(
+		multi_array_access_layout_build_flag_bits, enable_reordering)
+	XMIPP4_ENUM_TO_STR_CASE(
+		multi_array_access_layout_build_flag_bits, enable_coalescing)
 	default: return "";
 	}
 }

--- a/include/xmipp4/core/platform/enum_helpers.hpp
+++ b/include/xmipp4/core/platform/enum_helpers.hpp
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+#pragma once
+
+/**
+ * @def XMIPP4_ENUM_TO_STR_CASE(ns, x)
+ * @brief Generate a switch-case arm that returns the stringified enum value name.
+ *
+ * Expands to: `case ns::x: return "x"`;
+ *
+ * @param ns The enum class name (used as the scope qualifier).
+ * @param x  The enumerator name.
+ */
+#define XMIPP4_ENUM_TO_STR_CASE(ns, x) case ns::x: return #x;

--- a/src/core/numerical_type.cpp
+++ b/src/core/numerical_type.cpp
@@ -2,6 +2,7 @@
 
 #include <xmipp4/core/numerical_type.hpp>
 
+#include <xmipp4/core/platform/enum_helpers.hpp>
 #include <xmipp4/core/fixed_float.hpp>
 
 #include "numerical_type_promotion_lattice.hpp"
@@ -194,22 +195,22 @@ const char* to_string(numerical_type type) noexcept
 {
 	switch (type)
 	{
-	case numerical_type::boolean: return "boolean";
-	case numerical_type::char8: return "char8";
-	case numerical_type::int8: return "int8";
-	case numerical_type::uint8: return "uint8";
-	case numerical_type::int16: return "int16";
-	case numerical_type::uint16: return "uint16";
-	case numerical_type::int32: return "int32";
-	case numerical_type::uint32: return "uint32";
-	case numerical_type::int64: return "int64";
-	case numerical_type::uint64: return "uint64";
-	case numerical_type::float16: return "float16";
-	case numerical_type::float32: return "float32";
-	case numerical_type::float64: return "float64";
-	case numerical_type::complex_float16: return "complex_float16";
-	case numerical_type::complex_float32: return "complex_float32";
-	case numerical_type::complex_float64: return "complex_float64";
+	XMIPP4_ENUM_TO_STR_CASE(numerical_type, boolean)
+	XMIPP4_ENUM_TO_STR_CASE(numerical_type, char8)
+	XMIPP4_ENUM_TO_STR_CASE(numerical_type, int8)
+	XMIPP4_ENUM_TO_STR_CASE(numerical_type, uint8)
+	XMIPP4_ENUM_TO_STR_CASE(numerical_type, int16)
+	XMIPP4_ENUM_TO_STR_CASE(numerical_type, uint16)
+	XMIPP4_ENUM_TO_STR_CASE(numerical_type, int32)
+	XMIPP4_ENUM_TO_STR_CASE(numerical_type, uint32)
+	XMIPP4_ENUM_TO_STR_CASE(numerical_type, int64)
+	XMIPP4_ENUM_TO_STR_CASE(numerical_type, uint64)
+	XMIPP4_ENUM_TO_STR_CASE(numerical_type, float16)
+	XMIPP4_ENUM_TO_STR_CASE(numerical_type, float32)
+	XMIPP4_ENUM_TO_STR_CASE(numerical_type, float64)
+	XMIPP4_ENUM_TO_STR_CASE(numerical_type, complex_float16)
+	XMIPP4_ENUM_TO_STR_CASE(numerical_type, complex_float32)
+	XMIPP4_ENUM_TO_STR_CASE(numerical_type, complex_float64)
 	default: return "";
 	}
 }
@@ -218,12 +219,12 @@ const char* to_string(numerical_type_category category) noexcept
 {
 	switch (category)
 	{
-	case numerical_type_category::boolean: return "boolean";
-	case numerical_type_category::character: return "character";
-	case numerical_type_category::signed_integer: return "signed_integer";
-	case numerical_type_category::unsigned_integer: return "unsigned_integer";
-	case numerical_type_category::floating_point: return "floating_point";
-	case numerical_type_category::complex: return "complex";
+	XMIPP4_ENUM_TO_STR_CASE(numerical_type_category, boolean)
+	XMIPP4_ENUM_TO_STR_CASE(numerical_type_category, character)
+	XMIPP4_ENUM_TO_STR_CASE(numerical_type_category, signed_integer)
+	XMIPP4_ENUM_TO_STR_CASE(numerical_type_category, unsigned_integer)
+	XMIPP4_ENUM_TO_STR_CASE(numerical_type_category, floating_point)
+	XMIPP4_ENUM_TO_STR_CASE(numerical_type_category, complex)
 	default: return "";
 	}
 }


### PR DESCRIPTION
Reducing (but not eliminating) boilerplate