### PR TITLE
Dependency improvements

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "scikit-build-core==0.11.*"
+    "scikit-build-core==0.12.2"
 ]
 build-backend = "scikit_build_core.build"
 


### PR DESCRIPTION
- Update scikit-build-core version to 0.12.2
- Dependencies are now pinned and tracked by dependabot (not only github actions)