### PR TITLE
Windows 2025 fixes

### DIFF
--- a/conda/visual-studio-name-detector.ps1
+++ b/conda/visual-studio-name-detector.ps1
@@ -9,11 +9,15 @@ $displayVersion = & vswhere `
     -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
     -property catalog_productDisplayVersion
 
-$releaseYear = & vswhere `
-    -latest `
-    -products * `
-    -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
-    -property catalog_productLineVersion
+$majorVersion = [int]$displayVersion.Split('.')[0]
 
-$majorVersion = $displayVersion.Split('.')[0]
+# Map major version to release year. catalog_productLineVersion is unreliable
+# for VS 2026+ (returns the major number instead of the year).
+$yearMap = @{15 = 2017; 16 = 2019; 17 = 2022; 18 = 2026}
+$releaseYear = $yearMap[$majorVersion]
+if (-not $releaseYear) {
+    Write-Error "Unsupported Visual Studio major version: $majorVersion"
+    exit 1
+}
+
 Write-Output "Visual Studio $majorVersion $releaseYear"

--- a/src/core/system/dynamic_library_handle_windows.inl
+++ b/src/core/system/dynamic_library_handle_windows.inl
@@ -13,7 +13,13 @@ namespace system
 
 inline void* dynamic_library_open(const char* filename)
 {
+	DWORD prev_error_mode;
+	::SetThreadErrorMode(
+		SEM_FAILCRITICALERRORS | SEM_NOGPFAULTERRORBOX,
+		&prev_error_mode
+	);
 	const auto result = static_cast<void*>(::LoadLibrary(filename));
+	::SetThreadErrorMode(prev_error_mode, nullptr);
 	if (result == NULL)
 	{
 		throw std::system_error(


### PR DESCRIPTION
1. In VS 2026+ the VS version extraction method we were using did not work anymore.
2. In Windows 2025 failing to open a DLL creates a user dialogue, which hangs the test.
