### PR TITLE
Adding an accept method to operation policies

### DIFF
--- a/include/xmipp4/core/multidimensional/operation_data_type_policy.hpp
+++ b/include/xmipp4/core/multidimensional/operation_data_type_policy.hpp
@@ -12,10 +12,21 @@ namespace multidimensional
 {
 
 /**
- * @brief Strategy interface that deduces the numerical types of an operation's 
- * output arrays from its input types.
+ * @brief Interface describing the deduction and admissibility of array
+ * data types for an operation.
  *
- * @see operation_shape_policy
+ * The contract is split in two roles:
+ *
+ *   * `deduce` is the single source of truth: from the input data types
+ *     alone, it produces the canonical output data types that the policy
+ *     would assign, and along the way performs every input-side check the
+ *     policy requires.
+ *   * `accept` is invoked only when the user supplies pre-allocated
+ *     outputs. It decides whether those user-supplied output data types
+ *     are admissible given the canonical ones produced by `deduce`. The
+ *     default implementation requires equality with the canonical types;
+ *     override only for policies that admit user outputs other than the
+ *     canonical one (e.g. type-converting copies).
  */
 class XMIPP4_CORE_API operation_data_type_policy
 {
@@ -31,22 +42,43 @@ public:
 	operator=(operation_data_type_policy &&other) = delete;
 
 	/**
-	 * @brief Deduce the numerical types of the output tensors.
+	 * @brief Compute canonical output data types from the input data types.
 	 *
-	 * Fills each element of @p output_types with the @ref numerical_type
-	 * that the operation would produce for the corresponding output tensor,
-	 * given the types of all input tensors in @p input_types.
+	 * Performs all input-side validation along the way. After this call,
+	 * @p canonical_output_types holds the data types the policy would
+	 * produce if the user had not pre-allocated outputs.
 	 *
-	 * @param output_types Writable span whose length equals the number of
-	 * output tensors; each entry is set to the deduced output type.
-	 * @param input_types Read-only span whose length equals the number of
-	 * input tensors; each entry holds the numerical type of the
-	 * corresponding input tensor.
+	 * @param canonical_output_types Output buffer, sized to the operation's 
+	 * output arity. Will be filled with the canonical data types.
+	 * @param input_types Data types of the input operands.
 	 */
 	virtual void deduce(
-		span<numerical_type> output_types,
+		span<numerical_type> canonical_output_types,
 		span<const numerical_type> input_types
 	) const = 0;
+
+	/**
+	 * @brief Decide whether user-supplied output data types are admissible.
+	 *
+	 * Called only when the user has pre-allocated outputs. By the time
+	 * this is invoked, `deduce` has already produced
+	 * @p canonical_output_types, so input-side validation has happened.
+	 * Throws on rejection.
+	 *
+	 * The default implementation requires @p user_output_types to be
+	 * equal to @p canonical_output_types; override only for policies
+	 * that admit user outputs other than the canonical one (e.g. when the
+	 * kernel performs a type conversion).
+	 *
+	 * @param user_output_types Data types of the user-supplied outputs.
+	 * @param canonical_output_types Data types produced by `deduce`.
+	 * @param input_types Data types of the input operands.
+	 */
+	virtual void accept(
+		span<const numerical_type> user_output_types,
+		span<const numerical_type> canonical_output_types,
+		span<const numerical_type> input_types
+	) const;
 };
 
 } // namespace multidimensional

--- a/include/xmipp4/core/multidimensional/operation_shape_policy.hpp
+++ b/include/xmipp4/core/multidimensional/operation_shape_policy.hpp
@@ -13,15 +13,25 @@ namespace multidimensional
 {
 
 /**
- * @brief Strategy interface that deduces the shapes of an operation's output 
- * arrays from its input shapes.
+ * @brief Interface describing the deduction and admissibility of array
+ * shapes for an operation.
  *
- * @see operation_data_type_policy
+ * The contract is split in two roles:
+ *
+ *   * `deduce` is the single source of truth: from the input shapes alone,
+ *     it produces the canonical output shapes that the policy would assign,
+ *     and along the way performs every input-side check the policy
+ *     requires.
+ *   * `accept` is invoked only when the user supplies pre-allocated
+ *     outputs. It decides whether those user-supplied output shapes are
+ *     admissible given the canonical ones produced by `deduce`. The
+ *     default implementation requires equality with the canonical shapes;
+ *     override only for policies that admit broader-but-compatible user
+ *     outputs.
  */
 class XMIPP4_CORE_API operation_shape_policy
 {
 public:
-	/// Sequence of extents, one per dimension.
 	using shape_type = std::vector<std::size_t>;
 
 	operation_shape_policy() noexcept;
@@ -35,22 +45,42 @@ public:
 	operator=(operation_shape_policy &&other) = delete;
 
 	/**
-	 * @brief Deduce the shapes of the output tensors.
+	 * @brief Compute canonical output shapes from the input shapes.
 	 *
-	 * Fills each element of @p output_shapes with the @ref shape_type
-	 * that the operation would produce for the corresponding output tensor,
-	 * given the shapes of all input tensors in @p input_shapes.
+	 * Performs all input-side validation along the way. After this call,
+	 * @p canonical_output_shapes holds the shapes the policy would produce
+	 * if the user had not pre-allocated outputs.
 	 *
-	 * @param output_shapes Writable span whose length equals the number of
-	 * output tensors; each entry is set to the deduced output shape.
-	 * @param input_shapes Read-only span whose length equals the number of
-	 * input tensors; each entry holds the shape of the corresponding input
-	 * tensor.
+	 * @param canonical_output_shapes Output buffer, sized to the operation's 
+	 * output arity. Will be filled with the canonical shapes.
+	 * @param input_shapes Shapes of the input operands.
 	 */
 	virtual void deduce(
-		span<shape_type> output_shapes,
+		span<shape_type> canonical_output_shapes,
 		span<const shape_type> input_shapes
 	) const = 0;
+
+	/**
+	 * @brief Decide whether user-supplied output shapes are admissible.
+	 *
+	 * Called only when the user has pre-allocated outputs. By the time
+	 * this is invoked, `deduce` has already produced
+	 * @p canonical_output_shapes, so input-side validation has happened.
+	 * Throws on rejection.
+	 *
+	 * The default implementation requires @p user_output_shapes to be
+	 * equal to @p canonical_output_shapes; override only for policies
+	 * that admit broader-but-compatible user outputs.
+	 *
+	 * @param user_output_shapes Shapes of the user-supplied outputs.
+	 * @param canonical_output_shapes Shapes produced by `deduce`.
+	 * @param input_shapes Shapes of the input operands.
+	 */
+	virtual void accept(
+		span<const shape_type> user_output_shapes,
+		span<const shape_type> canonical_output_shapes,
+		span<const shape_type> input_shapes
+	) const;
 };
 
 } // namespace multidimensional

--- a/src/core/multidimensional/eager_operation_dispatcher.cpp
+++ b/src/core/multidimensional/eager_operation_dispatcher.cpp
@@ -114,6 +114,7 @@ resolve_output_descriptors(
 	span<const array> output_operands,
 	span<const operation_shape_policy::shape_type> canonical_shapes,
 	span<const numerical_type> canonical_data_types,
+	bool &accept,
 	std::integral_constant<std::size_t, N> /*small_cap_tag*/
 )
 {
@@ -130,6 +131,7 @@ resolve_output_descriptors(
 		if (output_operand.get_storage())
 		{
 			result.push_back(output_operand.get_descriptor());
+			accept = true;
 		}
 		else
 		{
@@ -348,12 +350,7 @@ void eager_operation_dispatcher::dispatch(
 	
 	const auto n_outputs = output_operands.size();
 	const auto n_inputs = input_operands.size();
-
-	const auto arity = op.get_arity();
-	const auto &shape_policy = op.get_operation_shape_policy();
-	const auto &data_type_policy = op.get_operation_data_type_policy();
-
-	validate_arity(operation_arity(n_outputs, n_inputs), arity);
+	validate_arity(operation_arity(n_outputs, n_inputs), op.get_arity());
 
 	auto input_descriptors = extract_input_descriptors(
 		input_operands,
@@ -368,6 +365,9 @@ void eager_operation_dispatcher::dispatch(
 		small_input_size_tag()
 	);
 
+	const auto &shape_policy = op.get_operation_shape_policy();
+	const auto &data_type_policy = op.get_operation_data_type_policy();
+
 	auto canonical_output_shapes =
 		make_empty_shapes(n_outputs, small_output_size_tag());
 	auto canonical_output_data_types =
@@ -381,31 +381,37 @@ void eager_operation_dispatcher::dispatch(
 		make_span(input_data_types.data(), n_inputs)
 	);
 
+	bool needs_acceptance = false;
 	auto output_descriptors = resolve_output_descriptors(
 		output_operands,
 		make_span(canonical_output_shapes.data(), n_outputs),
 		make_span(canonical_output_data_types.data(), n_outputs),
+		needs_acceptance,
 		small_output_size_tag()
 	);
-	auto output_shapes = extract_shapes(
-		make_span(output_descriptors.data(), n_outputs),
-		small_input_size_tag()
-	);
-	auto output_data_types = extract_data_types(
-		make_span(output_descriptors.data(), n_outputs),
-		small_input_size_tag()
-	);
 
-	shape_policy.accept(
-		make_span(output_shapes.data(), n_outputs),
-		make_span(canonical_output_shapes.data(), n_outputs),
-		make_span(input_shapes.data(), n_inputs)
-	);
-	data_type_policy.accept(
-		make_span(output_data_types.data(), n_outputs),
-		make_span(canonical_output_data_types.data(), n_outputs),
-		make_span(input_data_types.data(), n_inputs)
-	);
+	if (needs_acceptance)
+	{
+		auto output_shapes = extract_shapes(
+			make_span(output_descriptors.data(), n_outputs),
+			small_input_size_tag()
+		);
+		auto output_data_types = extract_data_types(
+			make_span(output_descriptors.data(), n_outputs),
+			small_input_size_tag()
+		);
+
+		shape_policy.accept(
+			make_span(output_shapes.data(), n_outputs),
+			make_span(canonical_output_shapes.data(), n_outputs),
+			make_span(input_shapes.data(), n_inputs)
+		);
+		data_type_policy.accept(
+			make_span(output_data_types.data(), n_outputs),
+			make_span(canonical_output_data_types.data(), n_outputs),
+			make_span(input_data_types.data(), n_inputs)
+		);
+	}
 
 	auto input_storages = extract_input_storage(
 		input_operands,

--- a/src/core/multidimensional/eager_operation_dispatcher.cpp
+++ b/src/core/multidimensional/eager_operation_dispatcher.cpp
@@ -114,7 +114,7 @@ resolve_output_descriptors(
 	span<const array> output_operands,
 	span<const operation_shape_policy::shape_type> canonical_shapes,
 	span<const numerical_type> canonical_data_types,
-	bool &accept,
+	bool &needs_acceptance,
 	std::integral_constant<std::size_t, N> /*small_cap_tag*/
 )
 {
@@ -131,7 +131,7 @@ resolve_output_descriptors(
 		if (output_operand.get_storage())
 		{
 			result.push_back(output_operand.get_descriptor());
-			accept = true;
+			needs_acceptance = true;
 		}
 		else
 		{

--- a/src/core/multidimensional/eager_operation_dispatcher.cpp
+++ b/src/core/multidimensional/eager_operation_dispatcher.cpp
@@ -388,11 +388,11 @@ void eager_operation_dispatcher::dispatch(
 		small_output_size_tag()
 	);
 	auto output_shapes = extract_shapes(
-		make_span(output_descriptors.data(), n_inputs),
+		make_span(output_descriptors.data(), n_outputs),
 		small_input_size_tag()
 	);
 	auto output_data_types = extract_data_types(
-		make_span(output_descriptors.data(), n_inputs),
+		make_span(output_descriptors.data(), n_outputs),
 		small_input_size_tag()
 	);
 

--- a/src/core/multidimensional/eager_operation_dispatcher.cpp
+++ b/src/core/multidimensional/eager_operation_dispatcher.cpp
@@ -108,44 +108,6 @@ make_empty_data_types(
 	return boost::container::small_vector<numerical_type, N>(count);
 }
 
-array_descriptor resolve_output_descriptor(
-	std::size_t index,
-	const array &output_operand,
-	const operation_shape_policy::shape_type &canonical_shape,
-	numerical_type canonical_data_type
-)
-{
-	if (!output_operand.get_storage())
-	{
-		return array_descriptor(
-			strided_layout::make_contiguous_layout(make_span(canonical_shape)),
-			canonical_data_type
-		);
-	}
-
-	const auto &descriptor = output_operand.get_descriptor();
-	if (!descriptor.get_layout().extents_equal(make_span(canonical_shape)))
-	{
-		std::ostringstream oss;
-		oss << "eager_operation_dispatcher::dispatch: Pre-allocated "
-			<< "output array at index " << index << " does not match the "
-			<< "expected shape";
-		throw std::invalid_argument(oss.str());
-	}
-
-	if (descriptor.get_data_type() != canonical_data_type)
-	{
-		std::ostringstream oss;
-		oss << "eager_operation_dispatcher::dispatch: Pre-allocated "
-			<< "output array at index " << index << " has data type "
-			<< to_string(descriptor.get_data_type()) << " but expected "
-			<< to_string(canonical_data_type);
-		throw std::invalid_argument(oss.str());
-	}
-
-	return descriptor;
-}
-
 template <std::size_t N>
 boost::container::small_vector<array_descriptor, N>
 resolve_output_descriptors(
@@ -161,19 +123,28 @@ resolve_output_descriptors(
 
 	boost::container::small_vector<array_descriptor, N> result;
 	result.reserve(n);
-
 	for (std::size_t i = 0; i < n; ++i)
-	{
-		result.push_back(
-			resolve_output_descriptor(
-				i, 
-				output_operands[i], 
-				canonical_shapes[i], 
-				canonical_data_types[i]
-			)
-		);
+	{	
+		const auto &output_operand = output_operands[i];
+
+		if (output_operand.get_storage())
+		{
+			result.push_back(output_operand.get_descriptor());
+		}
+		else
+		{
+			const auto &canonical_shape = canonical_shapes[i];
+			const auto canonical_data_type = canonical_data_types[i];
+			result.emplace_back(
+				strided_layout::make_contiguous_layout(
+					make_span(canonical_shape)
+				),
+				canonical_data_type
+			);
+		}
 	}
 
+	XMIPP4_ASSERT(result.size() == n);
 	return result;
 }
 
@@ -378,7 +349,11 @@ void eager_operation_dispatcher::dispatch(
 	const auto n_outputs = output_operands.size();
 	const auto n_inputs = input_operands.size();
 
-	validate_arity(operation_arity(n_outputs, n_inputs), op.get_arity());
+	const auto arity = op.get_arity();
+	const auto &shape_policy = op.get_operation_shape_policy();
+	const auto &data_type_policy = op.get_operation_data_type_policy();
+
+	validate_arity(operation_arity(n_outputs, n_inputs), arity);
 
 	auto input_descriptors = extract_input_descriptors(
 		input_operands,
@@ -393,27 +368,43 @@ void eager_operation_dispatcher::dispatch(
 		small_input_size_tag()
 	);
 
-	const auto &shape_policy = op.get_operation_shape_policy();
-	const auto &data_type_policy = op.get_operation_data_type_policy();
-
-	auto output_shapes =
+	auto canonical_output_shapes =
 		make_empty_shapes(n_outputs, small_output_size_tag());
-	auto output_data_types =
+	auto canonical_output_data_types =
 		make_empty_data_types(n_outputs, small_output_size_tag());
 	shape_policy.deduce(
-		make_span(output_shapes.data(), n_outputs),
+		make_span(canonical_output_shapes.data(), n_outputs),
 		make_span(input_shapes.data(), n_inputs)
 	);
 	data_type_policy.deduce(
-		make_span(output_data_types.data(), n_outputs),
+		make_span(canonical_output_data_types.data(), n_outputs),
 		make_span(input_data_types.data(), n_inputs)
 	);
 
 	auto output_descriptors = resolve_output_descriptors(
 		output_operands,
-		make_span(output_shapes.data(), n_outputs),
-		make_span(output_data_types.data(), n_outputs),
+		make_span(canonical_output_shapes.data(), n_outputs),
+		make_span(canonical_output_data_types.data(), n_outputs),
 		small_output_size_tag()
+	);
+	auto output_shapes = extract_shapes(
+		make_span(output_descriptors.data(), n_inputs),
+		small_input_size_tag()
+	);
+	auto output_data_types = extract_data_types(
+		make_span(output_descriptors.data(), n_inputs),
+		small_input_size_tag()
+	);
+
+	shape_policy.accept(
+		make_span(output_shapes.data(), n_outputs),
+		make_span(canonical_output_shapes.data(), n_outputs),
+		make_span(input_shapes.data(), n_inputs)
+	);
+	data_type_policy.accept(
+		make_span(output_data_types.data(), n_outputs),
+		make_span(canonical_output_data_types.data(), n_outputs),
+		make_span(input_data_types.data(), n_inputs)
 	);
 
 	auto input_storages = extract_input_storage(

--- a/src/core/multidimensional/operation_data_type_policy.cpp
+++ b/src/core/multidimensional/operation_data_type_policy.cpp
@@ -15,5 +15,27 @@ namespace multidimensional
 operation_data_type_policy::operation_data_type_policy() noexcept = default;
 operation_data_type_policy::~operation_data_type_policy() = default;
 
+void operation_data_type_policy::accept(
+	span<const numerical_type> user_output_types,
+	span<const numerical_type> canonical_output_types,
+	span<const numerical_type> /*input_types*/
+) const
+{
+	XMIPP4_ASSERT(user_output_types.size() == canonical_output_types.size());
+
+	for (std::size_t i = 0; i < user_output_types.size(); ++i)
+	{
+		if (user_output_types[i] != canonical_output_types[i])
+		{
+			std::ostringstream oss;
+			oss << "user-supplied output data type at index " << i
+				<< " (" << user_output_types[i]
+				<< ") does not match the data type deduced from the inputs"
+				<< " (" << canonical_output_types[i] << ").";
+			throw std::invalid_argument(oss.str());
+		}
+	}
+}
+
 } // namespace multidimensional
 } // namespace xmipp4

--- a/src/core/multidimensional/operation_shape_policy.cpp
+++ b/src/core/multidimensional/operation_shape_policy.cpp
@@ -15,5 +15,25 @@ namespace multidimensional
 operation_shape_policy::operation_shape_policy() noexcept = default;
 operation_shape_policy::~operation_shape_policy() = default;
 
+void operation_shape_policy::accept(
+	span<const shape_type> user_output_shapes,
+	span<const shape_type> canonical_output_shapes,
+	span<const shape_type> /*input_shapes*/
+) const
+{
+	XMIPP4_ASSERT(user_output_shapes.size() == canonical_output_shapes.size());
+
+	for (std::size_t i = 0; i < user_output_shapes.size(); ++i)
+	{
+		if (user_output_shapes[i] != canonical_output_shapes[i])
+		{
+			std::ostringstream oss;
+			oss << "user-supplied output shape at index " << i
+				<< " does not match the shape deduced from the inputs.";
+			throw std::invalid_argument(oss.str());
+		}
+	}
+}
+
 } // namespace multidimensional
 } // namespace xmipp4

--- a/tests/unitary/src/core/multidimensional/mock/mock_operation_data_type_policy.hpp
+++ b/tests/unitary/src/core/multidimensional/mock/mock_operation_data_type_policy.hpp
@@ -4,9 +4,6 @@
 
 #include <xmipp4/core/multidimensional/operation_data_type_policy.hpp>
 
-#include <xmipp4/core/span.hpp>
-#include <xmipp4/core/numerical_type.hpp>
-
 #include <trompeloeil.hpp>
 
 namespace xmipp4
@@ -20,8 +17,17 @@ class mock_operation_data_type_policy
 public:
 	MAKE_CONST_MOCK2(
 		deduce,
-		void (
-			span<numerical_type> output_types,
+		void(
+			span<numerical_type> canonical_output_types,
+			span<const numerical_type> input_types
+		),
+		override
+	);
+	MAKE_CONST_MOCK3(
+		accept,
+		void(
+			span<const numerical_type> user_output_types,
+			span<const numerical_type> canonical_output_types,
 			span<const numerical_type> input_types
 		),
 		override

--- a/tests/unitary/src/core/multidimensional/mock/mock_operation_shape_policy.hpp
+++ b/tests/unitary/src/core/multidimensional/mock/mock_operation_shape_policy.hpp
@@ -4,8 +4,6 @@
 
 #include <xmipp4/core/multidimensional/operation_shape_policy.hpp>
 
-#include <xmipp4/core/span.hpp>
-
 #include <trompeloeil.hpp>
 
 namespace xmipp4
@@ -17,10 +15,21 @@ class mock_operation_shape_policy
 	: public operation_shape_policy
 {
 public:
+	using shape_type = operation_shape_policy::shape_type;
+
 	MAKE_CONST_MOCK2(
 		deduce,
-		void (
-			span<shape_type> output_shapes,
+		void(
+			span<shape_type> canonical_output_shapes,
+			span<const shape_type> input_shapes
+		),
+		override
+	);
+	MAKE_CONST_MOCK3(
+		accept,
+		void(
+			span<const shape_type> user_output_shapes,
+			span<const shape_type> canonical_output_shapes,
 			span<const shape_type> input_shapes
 		),
 		override

--- a/tests/unitary/src/core/multidimensional/test_eager_operation_dispatcher.cpp
+++ b/tests/unitary/src/core/multidimensional/test_eager_operation_dispatcher.cpp
@@ -142,9 +142,10 @@ protected:
 		);
 	}
 
-	// Expect both policies to be queried for admissibility of the resolved
-	// outputs. The dispatcher delegates this decision to the policies, so the
-	// mocks simply accept (they do not throw) regardless of the arguments.
+	// Expect both policies to be queried for admissibility. This only happens
+	// when at least one output is pre-allocated; the dispatcher delegates the
+	// decision to the policies, so the mocks simply accept (they do not throw)
+	// regardless of the arguments.
 	void expect_policies_accept()
 	{
 		expectations.push_back(
@@ -328,12 +329,6 @@ TEST_CASE_METHOD(
 	REQUIRE_CALL(op, get_arity())
 		.RETURN(operation_arity::unary()); // Expects one output and one input.
 
-	// The dispatcher queries the policies up front, before validating arity.
-	ALLOW_CALL(op, get_operation_shape_policy())
-		.LR_RETURN(shape_policy);
-	ALLOW_CALL(op, get_operation_data_type_policy())
-		.LR_RETURN(dtype_policy);
-
 	array output;
 	const array_view input;
 
@@ -357,7 +352,6 @@ TEST_CASE_METHOD(
 )
 {
 	expect_unary_operation(shape_type{4}, numerical_type::float32);
-	expect_policies_accept(); // Reached before the missing input storage throws.
 
 	array output;           // Fresh output, storage to be resolved.
 	const array_view input; // Input without any backing storage.
@@ -464,7 +458,6 @@ TEST_CASE_METHOD(
 	);
 
 	expect_unary_operation(out_shape, out_type);
-	expect_policies_accept();
 	register_program_builder();
 	expect_program_scratch(); // No scratch required.
 
@@ -554,7 +547,6 @@ TEST_CASE_METHOD(
 	);
 
 	expect_unary_operation(shape_type{4}, numerical_type::float32);
-	expect_policies_accept();
 	register_program_builder();
 
 	const hardware::program_scratch_requirement scratch_requirement(

--- a/tests/unitary/src/core/multidimensional/test_eager_operation_dispatcher.cpp
+++ b/tests/unitary/src/core/multidimensional/test_eager_operation_dispatcher.cpp
@@ -142,6 +142,33 @@ protected:
 		);
 	}
 
+	// Expect both policies to be queried for admissibility of the resolved
+	// outputs. The dispatcher delegates this decision to the policies, so the
+	// mocks simply accept (they do not throw) regardless of the arguments.
+	void expect_policies_accept()
+	{
+		expectations.push_back(
+			NAMED_REQUIRE_CALL(
+				shape_policy,
+				accept(
+					ANY(span<const shape_type>),
+					ANY(span<const shape_type>),
+					ANY(span<const shape_type>)
+				)
+			)
+		);
+		expectations.push_back(
+			NAMED_REQUIRE_CALL(
+				dtype_policy,
+				accept(
+					ANY(span<const numerical_type>),
+					ANY(span<const numerical_type>),
+					ANY(span<const numerical_type>)
+				)
+			)
+		);
+	}
+
 	// Register a builder so that the program manager resolves @ref program for
 	// @ref op.
 	void register_program_builder()
@@ -301,6 +328,12 @@ TEST_CASE_METHOD(
 	REQUIRE_CALL(op, get_arity())
 		.RETURN(operation_arity::unary()); // Expects one output and one input.
 
+	// The dispatcher queries the policies up front, before validating arity.
+	ALLOW_CALL(op, get_operation_shape_policy())
+		.LR_RETURN(shape_policy);
+	ALLOW_CALL(op, get_operation_data_type_policy())
+		.LR_RETURN(dtype_policy);
+
 	array output;
 	const array_view input;
 
@@ -324,6 +357,7 @@ TEST_CASE_METHOD(
 )
 {
 	expect_unary_operation(shape_type{4}, numerical_type::float32);
+	expect_policies_accept(); // Reached before the missing input storage throws.
 
 	array output;           // Fresh output, storage to be resolved.
 	const array_view input; // Input without any backing storage.
@@ -341,36 +375,75 @@ TEST_CASE_METHOD(
 
 TEST_CASE_METHOD(
 	eager_operation_dispatcher_fixture,
-	"eager_operation_dispatcher dispatch throws when a pre-allocated output does "
-	"not match the deduced descriptor",
+	"eager_operation_dispatcher dispatch accepts a pre-allocated output whose "
+	"shape or data type differs from the deduced descriptor",
 	"[eager_operation_dispatcher]"
 )
 {
 	// The operation deduces a contiguous {4} float32 output. A pre-allocated
-	// output that differs in either shape or data type must be rejected.
-	shape_type bad_shape;
-	numerical_type bad_type;
-	std::tie(bad_shape, bad_type) = GENERATE(
+	// output that differs in shape or data type is forwarded to the policies'
+	// accept(), which decide its admissibility; here they admit it.
+	shape_type user_shape;
+	numerical_type user_type;
+	std::tie(user_shape, user_type) = GENERATE(
 		table<shape_type, numerical_type>({
-			{ shape_type{2}, numerical_type::float32 }, // Wrong shape.
-			{ shape_type{4}, numerical_type::float64 }, // Wrong data type.
+			{ shape_type{2}, numerical_type::float32 }, // Different shape.
+			{ shape_type{4}, numerical_type::float64 }, // Different data type.
 		})
 	);
 
 	expect_unary_operation(shape_type{4}, numerical_type::float32);
 
-	array output(make_buffer(), make_descriptor(bad_shape, bad_type));
-	const array_view input;
+	// The policies are queried with the user-supplied descriptor alongside the
+	// canonical one deduced above, and accept it.
+	expectations.push_back(
+		NAMED_REQUIRE_CALL(
+			shape_policy,
+			accept(
+				ANY(span<const shape_type>),
+				ANY(span<const shape_type>),
+				ANY(span<const shape_type>)
+			)
+		)
+			.WITH(_1.size() == 1 && _1[0] == user_shape)       // User output.
+			.WITH(_2.size() == 1 && _2[0] == shape_type{4})    // Canonical.
+	);
+	expectations.push_back(
+		NAMED_REQUIRE_CALL(
+			dtype_policy,
+			accept(
+				ANY(span<const numerical_type>),
+				ANY(span<const numerical_type>),
+				ANY(span<const numerical_type>)
+			)
+		)
+			.WITH(_1.size() == 1 && _1[0] == user_type)               // User.
+			.WITH(_2.size() == 1 && _2[0] == numerical_type::float32) // Canonical.
+	);
 
-	CHECK_THROWS_AS(
+	register_program_builder();
+	expect_program_scratch(); // No scratch required.
+
+	// The pre-allocated output already owns storage, so no allocation happens:
+	// the existing buffer is reused as-is and the command is submitted normally.
+	const auto output_buffer = make_buffer();
+	array output(output_buffer, make_descriptor(user_shape, user_type));
+
+	const array_view input =
+		make_input_with_storage(shape_type{4}, numerical_type::float32);
+	expect_command_submission(output_buffer, input.share_storage());
+
+	CHECK_NOTHROW(
 		dispatcher->dispatch(
 			op,
 			make_span(&output, 1),
 			make_span(&input, 1),
 			context
-		),
-		std::invalid_argument
+		)
 	);
+
+	// The pre-allocated storage is preserved.
+	CHECK( output.get_storage() == output_buffer.get() );
 }
 
 TEST_CASE_METHOD(
@@ -391,6 +464,7 @@ TEST_CASE_METHOD(
 	);
 
 	expect_unary_operation(out_shape, out_type);
+	expect_policies_accept();
 	register_program_builder();
 	expect_program_scratch(); // No scratch required.
 
@@ -438,6 +512,7 @@ TEST_CASE_METHOD(
 	);
 
 	expect_unary_operation(out_shape, out_type);
+	expect_policies_accept();
 	register_program_builder();
 	expect_program_scratch(); // No scratch required.
 
@@ -479,6 +554,7 @@ TEST_CASE_METHOD(
 	);
 
 	expect_unary_operation(shape_type{4}, numerical_type::float32);
+	expect_policies_accept();
 	register_program_builder();
 
 	const hardware::program_scratch_requirement scratch_requirement(

--- a/tests/unitary/src/core/multidimensional/test_operation_data_type_policy.cpp
+++ b/tests/unitary/src/core/multidimensional/test_operation_data_type_policy.cpp
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+#include <xmipp4/core/multidimensional/operation_data_type_policy.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers.hpp>
+#include <catch2/matchers/catch_matchers_exception.hpp>
+
+#include <stdexcept>
+#include <vector>
+
+using namespace xmipp4;
+using namespace xmipp4::multidimensional;
+
+namespace
+{
+
+class stub_operation_data_type_policy : public operation_data_type_policy
+{
+public:
+	void deduce(
+		span<numerical_type> /*canonical_output_types*/,
+		span<const numerical_type> /*input_types*/
+	) const override {}
+};
+
+} // namespace
+
+TEST_CASE(
+	"operation_data_type_policy::accept should succeed with zero outputs",
+	"[operation_data_type_policy]"
+)
+{
+	const stub_operation_data_type_policy policy;
+	CHECK_NOTHROW( policy.accept({}, {}, {}) );
+}
+
+TEST_CASE(
+	"operation_data_type_policy::accept should succeed when single user"
+	" type equals canonical",
+	"[operation_data_type_policy]"
+)
+{
+	const stub_operation_data_type_policy policy;
+
+	const std::vector<numerical_type> user = { numerical_type::float32 };
+	const std::vector<numerical_type> canonical = { numerical_type::float32 };
+
+	CHECK_NOTHROW( policy.accept(make_span(user), make_span(canonical), {}) );
+}
+
+TEST_CASE(
+	"operation_data_type_policy::accept should succeed when all user types"
+	" equal canonical",
+	"[operation_data_type_policy]"
+)
+{
+	const stub_operation_data_type_policy policy;
+
+	const std::vector<numerical_type> user = {
+		numerical_type::float32, numerical_type::int32
+	};
+	const std::vector<numerical_type> canonical = {
+		numerical_type::float32, numerical_type::int32
+	};
+
+	CHECK_NOTHROW( policy.accept(make_span(user), make_span(canonical), {}) );
+}
+
+TEST_CASE(
+	"operation_data_type_policy::accept should throw when user type at"
+	" index 0 differs from canonical",
+	"[operation_data_type_policy]"
+)
+{
+	const stub_operation_data_type_policy policy;
+
+	const std::vector<numerical_type> user = { numerical_type::float32 };
+	const std::vector<numerical_type> canonical = { numerical_type::float64 };
+
+	REQUIRE_THROWS_MATCHES(
+		policy.accept(make_span(user), make_span(canonical), {}),
+		std::invalid_argument,
+		Catch::Matchers::Message(
+			"user-supplied output data type at index 0 (float32)"
+			" does not match the data type deduced from the inputs (float64)."
+		)
+	);
+}
+
+TEST_CASE(
+	"operation_data_type_policy::accept should throw when user type at a"
+	" later index differs from canonical",
+	"[operation_data_type_policy]"
+)
+{
+	const stub_operation_data_type_policy policy;
+
+	const std::vector<numerical_type> user = {
+		numerical_type::float32,
+		numerical_type::int32,
+		numerical_type::uint8
+	};
+	const std::vector<numerical_type> canonical = {
+		numerical_type::float32,
+		numerical_type::int32,
+		numerical_type::int64
+	};
+
+	REQUIRE_THROWS_MATCHES(
+		policy.accept(make_span(user), make_span(canonical), {}),
+		std::invalid_argument,
+		Catch::Matchers::Message(
+			"user-supplied output data type at index 2 (uint8)"
+			" does not match the data type deduced from the inputs (int64)."
+		)
+	);
+}

--- a/tests/unitary/src/core/multidimensional/test_operation_shape_policy.cpp
+++ b/tests/unitary/src/core/multidimensional/test_operation_shape_policy.cpp
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+#include <xmipp4/core/multidimensional/operation_shape_policy.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers.hpp>
+#include <catch2/matchers/catch_matchers_exception.hpp>
+
+#include <stdexcept>
+#include <vector>
+
+using namespace xmipp4;
+using namespace xmipp4::multidimensional;
+
+using shape_type = operation_shape_policy::shape_type;
+
+namespace
+{
+
+class stub_operation_shape_policy : public operation_shape_policy
+{
+public:
+	using shape_type = operation_shape_policy::shape_type;
+
+	void deduce(
+		span<shape_type> /*canonical_output_shapes*/,
+		span<const shape_type> /*input_shapes*/
+	) const override {}
+};
+
+} // namespace
+
+TEST_CASE(
+	"operation_shape_policy::accept should succeed with zero outputs",
+	"[operation_shape_policy]"
+)
+{
+	const stub_operation_shape_policy policy;
+	CHECK_NOTHROW( policy.accept({}, {}, {}) );
+}
+
+TEST_CASE(
+	"operation_shape_policy::accept should succeed when single user"
+	" shape equals canonical",
+	"[operation_shape_policy]"
+)
+{
+	const stub_operation_shape_policy policy;
+
+	const std::vector<shape_type> user = { {3, 4} };
+	const std::vector<shape_type> canonical = { {3, 4} };
+
+	CHECK_NOTHROW( policy.accept(make_span(user), make_span(canonical), {}) );
+}
+
+TEST_CASE(
+	"operation_shape_policy::accept should succeed when all user shapes"
+	" equal canonical",
+	"[operation_shape_policy]"
+)
+{
+	const stub_operation_shape_policy policy;
+
+	const std::vector<shape_type> user = { {2, 3}, {4, 5, 6}, {} };
+	const std::vector<shape_type> canonical = { {2, 3}, {4, 5, 6}, {} };
+
+	CHECK_NOTHROW( policy.accept(make_span(user), make_span(canonical), {}) );
+}
+
+TEST_CASE(
+	"operation_shape_policy::accept should throw when user shape at"
+	" index 0 differs from canonical",
+	"[operation_shape_policy]"
+)
+{
+	const stub_operation_shape_policy policy;
+
+	const std::vector<shape_type> user = { {3, 4} };
+	const std::vector<shape_type> canonical = { {3, 5} };
+
+	REQUIRE_THROWS_MATCHES(
+		policy.accept(make_span(user), make_span(canonical), {}),
+		std::invalid_argument,
+		Catch::Matchers::Message(
+			"user-supplied output shape at index 0"
+			" does not match the shape deduced from the inputs."
+		)
+	);
+}
+
+TEST_CASE(
+	"operation_shape_policy::accept should throw when user shape at a"
+	" later index differs from canonical",
+	"[operation_shape_policy]"
+)
+{
+	const stub_operation_shape_policy policy;
+
+	const std::vector<shape_type> user = { {2, 3}, {4, 5}, {1, 1} };
+	const std::vector<shape_type> canonical = { {2, 3}, {4, 5}, {1, 9} };
+
+	REQUIRE_THROWS_MATCHES(
+		policy.accept(make_span(user), make_span(canonical), {}),
+		std::invalid_argument,
+		Catch::Matchers::Message(
+			"user-supplied output shape at index 2"
+			" does not match the shape deduced from the inputs."
+		)
+	);
+}


### PR DESCRIPTION
This allows operations to accept user-supplied outputs with non-canonical shapes or data types