### PR TITLE
Added array transfers

### DIFF
--- a/include/xmipp4/core/multidimensional/array_transfer.hpp
+++ b/include/xmipp4/core/multidimensional/array_transfer.hpp
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+#pragma once
+
+#include "array.hpp"
+#include "array_view.hpp"
+
+namespace xmipp4 
+{
+namespace multidimensional
+{
+
+class execution_context;
+
+/**
+ * @brief Transfer an array from host to device memory.
+ * 
+ * If the array is already device-accessible, this operation returns an
+ * alias of the input array. Otherwise it behaves like `to_device_copy`
+ * 
+ * @param input Array to be transferred.
+ * @param context The execution environment.
+ * @return array The transferred array.
+ * 
+ * @warning The returned array may alias the input array. Thus modifications
+ * to it may have side-effects on the input array and vice-versa. Prefer 
+ * @ref to_device_copy if this is a concern.
+ */
+XMIPP4_CORE_API
+array to_device(array &input, const execution_context &context);
+
+/**
+ * @brief Transfer an array to device memory enforcing a copy.
+ * 
+ * @param input Array to be transferred.
+ * @param context The execution environment.
+ * @param out Optional array to reuse. If provided, its resources may be re-used
+ * and it will be overwritten with the newly created array.
+ * @return array The transferred array.
+ */
+XMIPP4_CORE_API
+array to_device_copy(
+	array_view input, 
+	const execution_context &context,
+	array *out = nullptr
+);
+
+/**
+ * @brief Transfer an array to host accessible memory.
+ * 
+ * If the array is already gost-accessible, this operation returns an
+ * alias of the input array. Otherwise it behaves like `to_host_copy`
+ * 
+ * @param input Array to be transferred.
+ * @param context The execution environment.
+ * @return array The transferred array.
+ * 
+ * @warning The returned array may alias the input array. Thus modifications
+ * to it may have side-effects on the input array and vice-versa. Prefer 
+ * @ref to_host_copy if this is a concern. 
+ */
+XMIPP4_CORE_API
+array to_host(array &input, const execution_context &context);
+
+/**
+ * @brief Transfer an array to host accessible memory enforcing a copy.
+ * 
+ * @param input Array to be transferred.
+ * @param context The execution environment.
+ * @param out Optional array to reuse. If provided, its resources may be re-used
+ * and it will be overwritten with the newly created array.
+ * @return array The transferred array.
+ */
+XMIPP4_CORE_API
+array to_host_copy(
+	array_view input, 
+	const execution_context &context,
+	array *out = nullptr
+);
+
+} // namespace multidimensional
+} // namespace xmipp4

--- a/include/xmipp4/core/multidimensional/array_transfer.hpp
+++ b/include/xmipp4/core/multidimensional/array_transfer.hpp
@@ -5,12 +5,59 @@
 #include "array.hpp"
 #include "array_view.hpp"
 
+#include <xmipp4/core/hardware/memory_resource_affinity.hpp>
+
 namespace xmipp4 
 {
 namespace multidimensional
 {
 
 class execution_context;
+
+/**
+ * @brief Transfer an array to memory with the requested affinity.
+ *
+ * If the array is already accessible from a memory resource with the
+ * requested affinity, this operation returns an alias of the input array.
+ * Otherwise it behaves like @ref transfer_copy.
+ *
+ * @param input Array to be transferred.
+ * @param affinity Affinity of the memory resource to transfer the array to.
+ * @param context The execution environment.
+ * @return array The transferred array.
+ *
+ * @warning The returned array may alias the input array. Thus modifications
+ * to it may have side-effects on the input array and vice-versa. Prefer
+ * @ref transfer_copy if this is a concern.
+ */
+XMIPP4_CORE_API
+array transfer(
+	array &input,
+	hardware::memory_resource_affinity affinity,
+	const execution_context &context
+);
+
+/**
+ * @brief Transfer an array to memory with the requested affinity enforcing a
+ * copy.
+ *
+ * Unlike @ref transfer, this operation always allocates fresh storage and
+ * copies the input into it, so the result never aliases the input.
+ *
+ * @param input Array to be transferred.
+ * @param affinity Affinity of the memory resource to transfer the array to.
+ * @param context The execution environment.
+ * @param out Optional array to reuse. If provided, its resources may be re-used
+ * and it will be overwritten with the newly created array.
+ * @return array The transferred array.
+ */
+XMIPP4_CORE_API
+array transfer_copy(
+	array_view input,
+	hardware::memory_resource_affinity affinity,
+	const execution_context &context,
+	array *out = nullptr
+);
 
 /**
  * @brief Transfer an array from host to device memory.

--- a/src/core/multidimensional/array_transfer.cpp
+++ b/src/core/multidimensional/array_transfer.cpp
@@ -15,8 +15,39 @@ namespace xmipp4
 namespace multidimensional
 {
 
-namespace
+array transfer(
+	array &input, 
+	hardware::memory_resource_affinity affinity,
+	const execution_context &context
+)
 {
+	const auto *storage = input.get_storage();
+	if (!storage)
+	{
+		throw std::invalid_argument(
+			"transfer: Expected an input with associated storage."
+		);
+	}
+
+	const auto &allocator = 
+		context.get_device_context().get_allocator(affinity);
+	if (!allocator)
+	{
+		throw std::invalid_argument(
+			"transfer: Expected a device context with an allocator for the "
+			"requested affinity."
+		);
+	}
+
+	const auto &source_resource = storage->get_memory_resource();
+	const auto &target_resource = allocator->get_memory_resource();
+	if (&source_resource == &target_resource)
+	{
+		return input.share();
+	}
+
+	return transfer_copy(input, affinity, context, nullptr);
+}
 
 array transfer_copy(
 	array_view input, 
@@ -48,47 +79,9 @@ array transfer_copy(
 	return result;
 }
 
-array transfer_alias(
-	array& input,
-	hardware::memory_resource_affinity affinity,
-	const execution_context &context
-)
-{
-	const auto *storage = input.get_storage();
-	if (!storage)
-	{
-		throw std::invalid_argument(
-			"Expected an input with associated storage."
-		);
-	}
-
-	const auto &allocator = 
-		context.get_device_context().get_allocator(affinity);
-	if (!allocator)
-	{
-		throw std::invalid_argument(
-			"Expected a device context with an allocator for the requested "
-			"affinity."
-		);
-	}
-
-	const auto &source_resource = storage->get_memory_resource();
-	const auto &target_resource = allocator->get_memory_resource();
-	if (&source_resource == &target_resource)
-	{
-		return input.share();
-	}
-
-	return transfer_copy(input, affinity, context, nullptr);
-}
-
-} // anonymous namespace
-
-
-
 array to_device(array &input, const execution_context &context)
 {
-	return transfer_alias(
+	return transfer(
 		input, 
 		hardware::memory_resource_affinity::device, 
 		context
@@ -111,7 +104,7 @@ array to_device_copy(
 
 array to_host(array &input, const execution_context &context)
 {
-	return transfer_alias(
+	return transfer(
 		input, 
 		hardware::memory_resource_affinity::host, 
 		context

--- a/src/core/multidimensional/array_transfer.cpp
+++ b/src/core/multidimensional/array_transfer.cpp
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+#include <xmipp4/core/multidimensional/array_transfer.hpp>
+
+#include <xmipp4/core/multidimensional/execution_context.hpp>
+#include <xmipp4/core/multidimensional/operation_execute.hpp>
+#include <xmipp4/core/multidimensional/array_creation.hpp>
+#include <xmipp4/core/multidimensional/array_descriptor.hpp>
+#include <xmipp4/core/multidimensional/operations/assignment/copy_operation.hpp>
+#include <xmipp4/core/hardware/buffer.hpp>
+#include <xmipp4/core/hardware/memory_allocator.hpp>
+
+namespace xmipp4 
+{
+namespace multidimensional
+{
+
+namespace
+{
+
+array transfer_copy(
+	array_view input, 
+	hardware::memory_resource_affinity affinity,
+	const execution_context &context,
+	array *out
+)
+{
+	const auto &input_descriptor = input.get_descriptor();
+
+	std::vector<std::size_t> input_extents;
+	input_descriptor.get_layout().get_extents(input_extents);
+
+	array result = empty(
+		array_descriptor(
+			strided_layout::make_contiguous_layout(make_span(input_extents)),
+			input_descriptor.get_data_type()
+		),
+		affinity,
+		context,
+		out
+	);
+	execute(
+		copy_operation(),
+		make_span(&result, 1),
+		make_span(&input, 1),
+		context
+	);
+	return result;
+}
+
+array transfer_alias(
+	array& input,
+	hardware::memory_resource_affinity affinity,
+	const execution_context &context
+)
+{
+	const auto *storage = input.get_storage();
+	if (!storage)
+	{
+		throw std::invalid_argument(
+			"Expected an input with associated storage."
+		);
+	}
+
+	const auto &allocator = 
+		context.get_device_context().get_allocator(affinity);
+	if (!allocator)
+	{
+		throw std::invalid_argument(
+			"Expected a device context with an allocator for the requested "
+			"affinity."
+		);
+	}
+
+	const auto &source_resource = storage->get_memory_resource();
+	const auto &target_resource = allocator->get_memory_resource();
+	if (&source_resource == &target_resource)
+	{
+		return input.share();
+	}
+
+	return transfer_copy(input, affinity, context, nullptr);
+}
+
+} // anonymous namespace
+
+
+
+array to_device(array &input, const execution_context &context)
+{
+	return transfer_alias(
+		input, 
+		hardware::memory_resource_affinity::device, 
+		context
+	);
+}
+
+array to_device_copy(
+	array_view input, 
+	const execution_context &context,
+	array *out
+)
+{
+	return transfer_copy(
+		std::move(input), 
+		hardware::memory_resource_affinity::device, 
+		context, 
+		out
+	);
+}
+
+array to_host(array &input, const execution_context &context)
+{
+	return transfer_alias(
+		input, 
+		hardware::memory_resource_affinity::host, 
+		context
+	);
+}
+
+array to_host_copy(
+	array_view input, 
+	const execution_context &context,
+	array *out
+)
+{
+	return transfer_copy(
+		std::move(input), 
+		hardware::memory_resource_affinity::host, 
+		context, 
+		out
+	);
+}
+
+} // namespace multidimensional
+} // namespace xmipp4

--- a/tests/unitary/src/core/multidimensional/test_array_transfer.cpp
+++ b/tests/unitary/src/core/multidimensional/test_array_transfer.cpp
@@ -1,0 +1,359 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <xmipp4/core/multidimensional/array_transfer.hpp>
+
+#include <xmipp4/core/multidimensional/execution_context.hpp>
+#include <xmipp4/core/multidimensional/array.hpp>
+#include <xmipp4/core/multidimensional/array_view.hpp>
+#include <xmipp4/core/multidimensional/array_descriptor.hpp>
+#include <xmipp4/core/multidimensional/strided_layout.hpp>
+#include <xmipp4/core/multidimensional/operation.hpp>
+#include <xmipp4/core/multidimensional/operations/assignment/copy_operation.hpp>
+#include <xmipp4/core/numerical_type.hpp>
+#include <xmipp4/core/span.hpp>
+#include <xmipp4/core/hardware/device_context.hpp>
+#include <xmipp4/core/hardware/device_instance.hpp>
+#include <xmipp4/core/hardware/device_properties.hpp>
+#include <xmipp4/core/hardware/memory_allocator.hpp>
+#include <xmipp4/core/hardware/command_queue.hpp>
+#include <xmipp4/core/hardware/buffer.hpp>
+#include <xmipp4/core/hardware/memory_resource_affinity.hpp>
+
+#include "mock/mock_operation_dispatcher.hpp"
+#include "../hardware/mock/mock_device.hpp"
+#include "../hardware/mock/mock_memory_resource.hpp"
+#include "../hardware/mock/mock_memory_allocator.hpp"
+#include "../hardware/mock/mock_command_queue.hpp"
+#include "../hardware/mock/mock_buffer.hpp"
+
+#include <cstddef>
+#include <memory>
+#include <stdexcept>
+#include <typeinfo>
+#include <vector>
+
+using namespace xmipp4;
+using namespace xmipp4::multidimensional;
+using trompeloeil::_;
+
+namespace
+{
+
+// Records the arguments seen by a mocked dispatch() call so that they can be
+// inspected after the function under test has returned. The operation type is
+// captured by value to stay valid past the operation's (temporary) lifetime.
+struct dispatch_record
+{
+	bool called = false;
+	const std::type_info *operation_type = nullptr;
+	std::size_t num_outputs = 0;
+	std::size_t num_inputs = 0;
+	const hardware::buffer *first_output_storage = nullptr;
+	const hardware::buffer *first_input_storage = nullptr;
+	const hardware::device_instance *device_instance = nullptr;
+
+	void operator()(
+		const operation &op,
+		span<array> outputs,
+		span<const array_view> inputs,
+		const hardware::device_context &device_context
+	)
+	{
+		called = true;
+		operation_type = &typeid(op);
+		num_outputs = outputs.size();
+		num_inputs = inputs.size();
+		if (!outputs.empty())
+		{
+			first_output_storage = outputs[0].get_storage();
+		}
+		if (!inputs.empty())
+		{
+			first_input_storage = inputs[0].get_storage();
+		}
+		device_instance = device_context.get_device_instance().get();
+	}
+};
+
+class array_transfer_fixture
+{
+public:
+	array_transfer_fixture()
+		: device(std::make_shared<hardware::mock_device>())
+		, host_allocator(std::make_shared<hardware::mock_memory_allocator>())
+		, device_allocator(std::make_shared<hardware::mock_memory_allocator>())
+		, default_queue(std::make_shared<hardware::mock_command_queue>())
+		, dispatcher(std::make_shared<mock_operation_dispatcher>())
+	{
+		using hardware::memory_resource_affinity;
+
+		hardware::device_properties properties;
+		properties.set_optimal_data_alignment(128);
+
+		REQUIRE_CALL(
+			*device,
+			get_memory_resource(memory_resource_affinity::host)
+		)
+			.LR_RETURN(host_resource);
+		REQUIRE_CALL(
+			*device,
+			get_memory_resource(memory_resource_affinity::device)
+		)
+			.LR_RETURN(device_resource);
+		REQUIRE_CALL(host_resource, create_allocator())
+			.RETURN(host_allocator);
+		REQUIRE_CALL(device_resource, create_allocator())
+			.RETURN(device_allocator);
+		REQUIRE_CALL(*device, create_command_queue())
+			.RETURN(default_queue);
+
+		instance = std::make_shared<hardware::device_instance>(
+			device,
+			std::move(properties)
+		);
+
+		context = execution_context(
+			hardware::device_context(instance),
+			dispatcher
+		);
+	}
+
+protected:
+	array_descriptor make_descriptor(
+		std::vector<std::size_t> extents = { 2, 3 },
+		numerical_type data_type = numerical_type::float32
+	) const
+	{
+		return array_descriptor(
+			strided_layout::make_contiguous_layout(make_span(extents)),
+			data_type
+		);
+	}
+
+	std::shared_ptr<hardware::mock_device> device;
+	std::shared_ptr<hardware::mock_memory_allocator> host_allocator;
+	std::shared_ptr<hardware::mock_memory_allocator> device_allocator;
+	hardware::mock_memory_resource host_resource;
+	hardware::mock_memory_resource device_resource;
+	std::shared_ptr<hardware::command_queue> default_queue;
+	std::shared_ptr<const hardware::device_instance> instance;
+	std::shared_ptr<mock_operation_dispatcher> dispatcher;
+	execution_context context;
+};
+
+} // namespace
+
+
+
+TEST_CASE(
+	"to_device throws when the input array has no associated storage",
+	"[array_transfer]"
+)
+{
+	// A default-constructed array carries no storage.
+	array input;
+
+	// The context is irrelevant here: the storage check fails first.
+	const execution_context context;
+
+	CHECK_THROWS_AS( to_device(input, context), std::invalid_argument );
+}
+
+TEST_CASE(
+	"to_device throws when the execution context has no allocator for the "
+	"requested affinity",
+	"[array_transfer]"
+)
+{
+	const std::vector<std::size_t> extents = { 2, 3 };
+	const array_descriptor descriptor(
+		strided_layout::make_contiguous_layout(make_span(extents)),
+		numerical_type::float32
+	);
+	const auto buffer = std::make_shared<hardware::mock_buffer>();
+	array input(buffer, descriptor);
+
+	// A default-constructed context is empty: it has no allocators.
+	const execution_context context;
+
+	CHECK_THROWS_AS( to_device(input, context), std::invalid_argument );
+}
+
+TEST_CASE_METHOD(
+	array_transfer_fixture,
+	"to_device aliases the input when it already lives on the device memory "
+	"resource",
+	"[array_transfer]"
+)
+{
+	const auto descriptor = make_descriptor();
+	const auto buffer = std::make_shared<hardware::mock_buffer>();
+
+	// Both the input storage and the device allocator report the same memory
+	// resource, so the input must be aliased verbatim: no allocation and no
+	// copy dispatch are expected (an unexpected call would fail the test).
+	ALLOW_CALL(*buffer, get_memory_resource())
+		.LR_RETURN(device_resource);
+	ALLOW_CALL(*device_allocator, get_memory_resource())
+		.LR_RETURN(device_resource);
+
+	array input(buffer, descriptor);
+
+	const auto result = to_device(input, context);
+
+	CHECK( result.get_storage() == buffer.get() );
+	CHECK( result.get_descriptor() == descriptor );
+}
+
+TEST_CASE_METHOD(
+	array_transfer_fixture,
+	"to_device copies the input when it lives on a different memory resource",
+	"[array_transfer]"
+)
+{
+	const auto descriptor = make_descriptor();
+	const auto size = compute_storage_requirement(descriptor);
+	const auto source_buffer = std::make_shared<hardware::mock_buffer>();
+	const auto device_buffer = std::make_shared<hardware::mock_buffer>();
+
+	// The input lives on the host resource while the device allocator hands out
+	// device-resource storage, so aliasing is rejected and a copy is performed
+	// via a fresh allocation on the device allocator.
+	ALLOW_CALL(*source_buffer, get_memory_resource())
+		.LR_RETURN(host_resource);
+	ALLOW_CALL(*device_allocator, get_memory_resource())
+		.LR_RETURN(device_resource);
+	ALLOW_CALL(*device_allocator, get_max_alignment())
+		.RETURN(std::size_t(256));
+	REQUIRE_CALL(
+		*device_allocator,
+		allocate(size, _, default_queue.get())
+	)
+		.RETURN(device_buffer);
+
+	dispatch_record record;
+	REQUIRE_CALL(*dispatcher, dispatch(_, _, _, _))
+		.LR_SIDE_EFFECT( record(_1, _2, _3, _4) );
+
+	array input(source_buffer, descriptor);
+
+	const auto result = to_device(input, context);
+
+	CHECK( result.get_storage() == device_buffer.get() );
+	CHECK( record.called );
+	REQUIRE( record.operation_type != nullptr );
+	CHECK( *record.operation_type == typeid(copy_operation) );
+	CHECK( record.num_outputs == 1 );
+	CHECK( record.num_inputs == 1 );
+	CHECK( record.first_output_storage == device_buffer.get() );
+	CHECK( record.first_input_storage == source_buffer.get() );
+	CHECK( record.device_instance == instance.get() );
+}
+
+TEST_CASE_METHOD(
+	array_transfer_fixture,
+	"to_host aliases the input when it already lives on the host memory "
+	"resource",
+	"[array_transfer]"
+)
+{
+	const auto descriptor = make_descriptor();
+	const auto buffer = std::make_shared<hardware::mock_buffer>();
+
+	// Input storage and host allocator share the memory resource: alias only.
+	ALLOW_CALL(*buffer, get_memory_resource())
+		.LR_RETURN(host_resource);
+	ALLOW_CALL(*host_allocator, get_memory_resource())
+		.LR_RETURN(host_resource);
+
+	array input(buffer, descriptor);
+
+	const auto result = to_host(input, context);
+
+	CHECK( result.get_storage() == buffer.get() );
+	CHECK( result.get_descriptor() == descriptor );
+}
+
+TEST_CASE_METHOD(
+	array_transfer_fixture,
+	"to_device_copy allocates on the device allocator and dispatches a "
+	"copy_operation with the input as the single source",
+	"[array_transfer]"
+)
+{
+	const auto descriptor = make_descriptor();
+	const auto size = compute_storage_requirement(descriptor);
+	const auto source_buffer = std::make_shared<hardware::mock_buffer>();
+	const auto device_buffer = std::make_shared<hardware::mock_buffer>();
+
+	// A forced copy always allocates fresh device storage; only the device
+	// allocator is expected to be used.
+	ALLOW_CALL(*device_allocator, get_max_alignment())
+		.RETURN(std::size_t(256));
+	REQUIRE_CALL(
+		*device_allocator,
+		allocate(size, _, default_queue.get())
+	)
+		.RETURN(device_buffer);
+
+	dispatch_record record;
+	REQUIRE_CALL(*dispatcher, dispatch(_, _, _, _))
+		.LR_SIDE_EFFECT( record(_1, _2, _3, _4) );
+
+	array source(source_buffer, descriptor);
+
+	const auto result = to_device_copy(source.share(), context);
+
+	CHECK( result.get_storage() == device_buffer.get() );
+	CHECK( record.called );
+	REQUIRE( record.operation_type != nullptr );
+	CHECK( *record.operation_type == typeid(copy_operation) );
+	CHECK( record.num_outputs == 1 );
+	CHECK( record.num_inputs == 1 );
+	CHECK( record.first_output_storage == device_buffer.get() );
+	CHECK( record.first_input_storage == source_buffer.get() );
+	CHECK( record.device_instance == instance.get() );
+}
+
+TEST_CASE_METHOD(
+	array_transfer_fixture,
+	"to_host_copy allocates on the host allocator and dispatches a "
+	"copy_operation with the input as the single source",
+	"[array_transfer]"
+)
+{
+	const auto descriptor = make_descriptor();
+	const auto size = compute_storage_requirement(descriptor);
+	const auto source_buffer = std::make_shared<hardware::mock_buffer>();
+	const auto host_buffer = std::make_shared<hardware::mock_buffer>();
+
+	// A forced copy always allocates fresh host storage; only the host
+	// allocator is expected to be used.
+	ALLOW_CALL(*host_allocator, get_max_alignment())
+		.RETURN(std::size_t(256));
+	REQUIRE_CALL(
+		*host_allocator,
+		allocate(size, _, default_queue.get())
+	)
+		.RETURN(host_buffer);
+
+	dispatch_record record;
+	REQUIRE_CALL(*dispatcher, dispatch(_, _, _, _))
+		.LR_SIDE_EFFECT( record(_1, _2, _3, _4) );
+
+	array source(source_buffer, descriptor);
+
+	const auto result = to_host_copy(source.share(), context);
+
+	CHECK( result.get_storage() == host_buffer.get() );
+	CHECK( record.called );
+	REQUIRE( record.operation_type != nullptr );
+	CHECK( *record.operation_type == typeid(copy_operation) );
+	CHECK( record.num_outputs == 1 );
+	CHECK( record.num_inputs == 1 );
+	CHECK( record.first_output_storage == host_buffer.get() );
+	CHECK( record.first_input_storage == source_buffer.get() );
+	CHECK( record.device_instance == instance.get() );
+}

--- a/tests/unitary/src/core/multidimensional/test_array_transfer.cpp
+++ b/tests/unitary/src/core/multidimensional/test_array_transfer.cpp
@@ -147,8 +147,12 @@ protected:
 
 
 
+//
+// transfer
+//
+
 TEST_CASE(
-	"to_device throws when the input array has no associated storage",
+	"transfer throws when the input array has no associated storage",
 	"[array_transfer]"
 )
 {
@@ -158,11 +162,14 @@ TEST_CASE(
 	// The context is irrelevant here: the storage check fails first.
 	const execution_context context;
 
-	CHECK_THROWS_AS( to_device(input, context), std::invalid_argument );
+	CHECK_THROWS_AS(
+		transfer(input, hardware::memory_resource_affinity::host, context),
+		std::invalid_argument
+	);
 }
 
 TEST_CASE(
-	"to_device throws when the execution context has no allocator for the "
+	"transfer throws when the execution context has no allocator for the "
 	"requested affinity",
 	"[array_transfer]"
 )
@@ -178,12 +185,15 @@ TEST_CASE(
 	// A default-constructed context is empty: it has no allocators.
 	const execution_context context;
 
-	CHECK_THROWS_AS( to_device(input, context), std::invalid_argument );
+	CHECK_THROWS_AS(
+		transfer(input, hardware::memory_resource_affinity::host, context),
+		std::invalid_argument
+	);
 }
 
 TEST_CASE_METHOD(
 	array_transfer_fixture,
-	"to_device aliases the input when it already lives on the device memory "
+	"transfer aliases the input when it already lives on the target memory "
 	"resource",
 	"[array_transfer]"
 )
@@ -191,9 +201,185 @@ TEST_CASE_METHOD(
 	const auto descriptor = make_descriptor();
 	const auto buffer = std::make_shared<hardware::mock_buffer>();
 
-	// Both the input storage and the device allocator report the same memory
+	// Both the input storage and the target allocator report the same memory
 	// resource, so the input must be aliased verbatim: no allocation and no
 	// copy dispatch are expected (an unexpected call would fail the test).
+	ALLOW_CALL(*buffer, get_memory_resource())
+		.LR_RETURN(host_resource);
+	ALLOW_CALL(*host_allocator, get_memory_resource())
+		.LR_RETURN(host_resource);
+
+	array input(buffer, descriptor);
+
+	const auto result = transfer(
+		input,
+		hardware::memory_resource_affinity::host,
+		context
+	);
+
+	CHECK( result.get_storage() == buffer.get() );
+	CHECK( result.get_descriptor() == descriptor );
+}
+
+TEST_CASE_METHOD(
+	array_transfer_fixture,
+	"transfer copies the input when it lives on a different memory resource",
+	"[array_transfer]"
+)
+{
+	const auto descriptor = make_descriptor();
+	const auto size = compute_storage_requirement(descriptor);
+	const auto source_buffer = std::make_shared<hardware::mock_buffer>();
+	const auto target_buffer = std::make_shared<hardware::mock_buffer>();
+
+	// The input lives on the device resource while the host allocator hands out
+	// host-resource storage, so aliasing is rejected and a copy is performed
+	// via a fresh allocation on the host allocator.
+	ALLOW_CALL(*source_buffer, get_memory_resource())
+		.LR_RETURN(device_resource);
+	ALLOW_CALL(*host_allocator, get_memory_resource())
+		.LR_RETURN(host_resource);
+	ALLOW_CALL(*host_allocator, get_max_alignment())
+		.RETURN(std::size_t(256));
+	REQUIRE_CALL(
+		*host_allocator,
+		allocate(size, _, default_queue.get())
+	)
+		.RETURN(target_buffer);
+
+	dispatch_record record;
+	REQUIRE_CALL(*dispatcher, dispatch(_, _, _, _))
+		.LR_SIDE_EFFECT( record(_1, _2, _3, _4) );
+
+	array input(source_buffer, descriptor);
+
+	const auto result = transfer(
+		input,
+		hardware::memory_resource_affinity::host,
+		context
+	);
+
+	CHECK( result.get_storage() == target_buffer.get() );
+	CHECK( record.called );
+	REQUIRE( record.operation_type != nullptr );
+	CHECK( *record.operation_type == typeid(copy_operation) );
+	CHECK( record.num_outputs == 1 );
+	CHECK( record.num_inputs == 1 );
+	CHECK( record.first_output_storage == target_buffer.get() );
+	CHECK( record.first_input_storage == source_buffer.get() );
+	CHECK( record.device_instance == instance.get() );
+}
+
+
+
+//
+// transfer_copy
+//
+
+TEST_CASE_METHOD(
+	array_transfer_fixture,
+	"transfer_copy allocates on the target allocator and dispatches a "
+	"copy_operation with the input as the single source",
+	"[array_transfer]"
+)
+{
+	const auto descriptor = make_descriptor();
+	const auto size = compute_storage_requirement(descriptor);
+	const auto source_buffer = std::make_shared<hardware::mock_buffer>();
+	const auto target_buffer = std::make_shared<hardware::mock_buffer>();
+
+	// A forced copy always allocates fresh storage on the target allocator.
+	ALLOW_CALL(*host_allocator, get_max_alignment())
+		.RETURN(std::size_t(256));
+	REQUIRE_CALL(
+		*host_allocator,
+		allocate(size, _, default_queue.get())
+	)
+		.RETURN(target_buffer);
+
+	dispatch_record record;
+	REQUIRE_CALL(*dispatcher, dispatch(_, _, _, _))
+		.LR_SIDE_EFFECT( record(_1, _2, _3, _4) );
+
+	array source(source_buffer, descriptor);
+
+	const auto result = transfer_copy(
+		source.share(),
+		hardware::memory_resource_affinity::host,
+		context
+	);
+
+	CHECK( result.get_storage() == target_buffer.get() );
+	CHECK( record.called );
+	REQUIRE( record.operation_type != nullptr );
+	CHECK( *record.operation_type == typeid(copy_operation) );
+	CHECK( record.num_outputs == 1 );
+	CHECK( record.num_inputs == 1 );
+	CHECK( record.first_output_storage == target_buffer.get() );
+	CHECK( record.first_input_storage == source_buffer.get() );
+	CHECK( record.device_instance == instance.get() );
+}
+
+TEST_CASE_METHOD(
+	array_transfer_fixture,
+	"transfer_copy reuses the storage of the provided output array",
+	"[array_transfer]"
+)
+{
+	const auto descriptor = make_descriptor();
+	const auto size = compute_storage_requirement(descriptor);
+	const auto source_buffer = std::make_shared<hardware::mock_buffer>();
+	const auto out_buffer = std::make_shared<hardware::mock_buffer>();
+
+	// The output buffer lives on the target resource and is large enough, so it
+	// must be reused verbatim: no allocate() call is expected.
+	ALLOW_CALL(*out_buffer, get_memory_resource())
+		.LR_RETURN(host_resource);
+	ALLOW_CALL(*out_buffer, get_size())
+		.RETURN(size);
+	ALLOW_CALL(*host_allocator, get_memory_resource())
+		.LR_RETURN(host_resource);
+
+	dispatch_record record;
+	REQUIRE_CALL(*dispatcher, dispatch(_, _, _, _))
+		.LR_SIDE_EFFECT( record(_1, _2, _3, _4) );
+
+	array source(source_buffer, descriptor);
+	array out(out_buffer, descriptor);
+
+	const auto result = transfer_copy(
+		source.share(),
+		hardware::memory_resource_affinity::host,
+		context,
+		&out
+	);
+
+	// The output storage is reused and the copy dispatched into it.
+	CHECK( result.get_storage() == out_buffer.get() );
+	CHECK( out.get_storage() == out_buffer.get() );
+	CHECK( record.called );
+	CHECK( record.first_output_storage == out_buffer.get() );
+	CHECK( record.first_input_storage == source_buffer.get() );
+}
+
+
+
+//
+// to_device / to_host / to_device_copy / to_host_copy wrappers
+//
+
+TEST_CASE_METHOD(
+	array_transfer_fixture,
+	"to_device transfers using the device affinity",
+	"[array_transfer]"
+)
+{
+	const auto descriptor = make_descriptor();
+	const auto buffer = std::make_shared<hardware::mock_buffer>();
+
+	// The input lives on the device resource. Aliasing therefore proves that
+	// to_device consulted the device allocator (a host allocator would report a
+	// different resource and force a copy instead).
 	ALLOW_CALL(*buffer, get_memory_resource())
 		.LR_RETURN(device_resource);
 	ALLOW_CALL(*device_allocator, get_memory_resource())
@@ -204,65 +390,18 @@ TEST_CASE_METHOD(
 	const auto result = to_device(input, context);
 
 	CHECK( result.get_storage() == buffer.get() );
-	CHECK( result.get_descriptor() == descriptor );
 }
 
 TEST_CASE_METHOD(
 	array_transfer_fixture,
-	"to_device copies the input when it lives on a different memory resource",
-	"[array_transfer]"
-)
-{
-	const auto descriptor = make_descriptor();
-	const auto size = compute_storage_requirement(descriptor);
-	const auto source_buffer = std::make_shared<hardware::mock_buffer>();
-	const auto device_buffer = std::make_shared<hardware::mock_buffer>();
-
-	// The input lives on the host resource while the device allocator hands out
-	// device-resource storage, so aliasing is rejected and a copy is performed
-	// via a fresh allocation on the device allocator.
-	ALLOW_CALL(*source_buffer, get_memory_resource())
-		.LR_RETURN(host_resource);
-	ALLOW_CALL(*device_allocator, get_memory_resource())
-		.LR_RETURN(device_resource);
-	ALLOW_CALL(*device_allocator, get_max_alignment())
-		.RETURN(std::size_t(256));
-	REQUIRE_CALL(
-		*device_allocator,
-		allocate(size, _, default_queue.get())
-	)
-		.RETURN(device_buffer);
-
-	dispatch_record record;
-	REQUIRE_CALL(*dispatcher, dispatch(_, _, _, _))
-		.LR_SIDE_EFFECT( record(_1, _2, _3, _4) );
-
-	array input(source_buffer, descriptor);
-
-	const auto result = to_device(input, context);
-
-	CHECK( result.get_storage() == device_buffer.get() );
-	CHECK( record.called );
-	REQUIRE( record.operation_type != nullptr );
-	CHECK( *record.operation_type == typeid(copy_operation) );
-	CHECK( record.num_outputs == 1 );
-	CHECK( record.num_inputs == 1 );
-	CHECK( record.first_output_storage == device_buffer.get() );
-	CHECK( record.first_input_storage == source_buffer.get() );
-	CHECK( record.device_instance == instance.get() );
-}
-
-TEST_CASE_METHOD(
-	array_transfer_fixture,
-	"to_host aliases the input when it already lives on the host memory "
-	"resource",
+	"to_host transfers using the host affinity",
 	"[array_transfer]"
 )
 {
 	const auto descriptor = make_descriptor();
 	const auto buffer = std::make_shared<hardware::mock_buffer>();
 
-	// Input storage and host allocator share the memory resource: alias only.
+	// Aliasing against the host resource proves the host allocator was used.
 	ALLOW_CALL(*buffer, get_memory_resource())
 		.LR_RETURN(host_resource);
 	ALLOW_CALL(*host_allocator, get_memory_resource())
@@ -273,13 +412,11 @@ TEST_CASE_METHOD(
 	const auto result = to_host(input, context);
 
 	CHECK( result.get_storage() == buffer.get() );
-	CHECK( result.get_descriptor() == descriptor );
 }
 
 TEST_CASE_METHOD(
 	array_transfer_fixture,
-	"to_device_copy allocates on the device allocator and dispatches a "
-	"copy_operation with the input as the single source",
+	"to_device_copy allocates on the device allocator",
 	"[array_transfer]"
 )
 {
@@ -288,8 +425,7 @@ TEST_CASE_METHOD(
 	const auto source_buffer = std::make_shared<hardware::mock_buffer>();
 	const auto device_buffer = std::make_shared<hardware::mock_buffer>();
 
-	// A forced copy always allocates fresh device storage; only the device
-	// allocator is expected to be used.
+	// Only the device allocator is expected to be used.
 	ALLOW_CALL(*device_allocator, get_max_alignment())
 		.RETURN(std::size_t(256));
 	REQUIRE_CALL(
@@ -308,19 +444,13 @@ TEST_CASE_METHOD(
 
 	CHECK( result.get_storage() == device_buffer.get() );
 	CHECK( record.called );
-	REQUIRE( record.operation_type != nullptr );
 	CHECK( *record.operation_type == typeid(copy_operation) );
-	CHECK( record.num_outputs == 1 );
-	CHECK( record.num_inputs == 1 );
-	CHECK( record.first_output_storage == device_buffer.get() );
 	CHECK( record.first_input_storage == source_buffer.get() );
-	CHECK( record.device_instance == instance.get() );
 }
 
 TEST_CASE_METHOD(
 	array_transfer_fixture,
-	"to_host_copy allocates on the host allocator and dispatches a "
-	"copy_operation with the input as the single source",
+	"to_host_copy allocates on the host allocator",
 	"[array_transfer]"
 )
 {
@@ -329,8 +459,7 @@ TEST_CASE_METHOD(
 	const auto source_buffer = std::make_shared<hardware::mock_buffer>();
 	const auto host_buffer = std::make_shared<hardware::mock_buffer>();
 
-	// A forced copy always allocates fresh host storage; only the host
-	// allocator is expected to be used.
+	// Only the host allocator is expected to be used.
 	ALLOW_CALL(*host_allocator, get_max_alignment())
 		.RETURN(std::size_t(256));
 	REQUIRE_CALL(
@@ -349,11 +478,6 @@ TEST_CASE_METHOD(
 
 	CHECK( result.get_storage() == host_buffer.get() );
 	CHECK( record.called );
-	REQUIRE( record.operation_type != nullptr );
 	CHECK( *record.operation_type == typeid(copy_operation) );
-	CHECK( record.num_outputs == 1 );
-	CHECK( record.num_inputs == 1 );
-	CHECK( record.first_output_storage == host_buffer.get() );
 	CHECK( record.first_input_storage == source_buffer.get() );
-	CHECK( record.device_instance == instance.get() );
 }


### PR DESCRIPTION
Array transfers will be used to submit/receive data from/to devices like GPUs.