### PR TITLE
Switched coverage report format

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,4 +4,4 @@ sonar.sources=src, include, .github
 sonar.tests=tests
 sonar.exclusions=doc/**, conda.recipe/**
 sonar.cfamily.compile-commands=build/compile_commands.json
-sonar.cfamily.cobertura.reportPaths=build/coverage.xml
+sonar.coverageReportPaths=build/coverage.xml


### PR DESCRIPTION
This should significantly accelerate coverage report generation times.
Adapted from [this commit](https://github.com/gigabit-clowns/.github/commit/df68fb1c5a82ff8bfb69b2d1f4f631b4e3747961) in .github repository.

This is because gcovr's Cobertura writer has an O(n_functions × n_lines) cost per file when generating the report. In template-heavy files, where a single source line ends up compiled into many distinct instantiations, the number of instrumented functions per file can reach into the tens of thousands — turning that per-file cost into several minutes of wall-clock time. JaCoCo doesn't have this cost, so switching format keeps the same underlying data without the quadratic report-generation overhead.